### PR TITLE
bugfix : 뒤로가기 두번 누르면 빈화면으로 가는 버그

### DIFF
--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/USaintNavHost.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/USaintNavHost.kt
@@ -47,7 +47,7 @@ fun USaintNavHost(
                     }
                 )
             },
-            navigateToBack = { navController.popBackStack() },
+            navigateToBack = { navController.navigateUp() },
         )
 
         homeScreen(
@@ -57,7 +57,7 @@ fun USaintNavHost(
 
         settingScreen(
             navigateToBack = {
-                navController.popBackStack()
+                navController.navigateUp()
             },
             navigateToWebView = { url ->
                 CustomTabsIntent.Builder().build().also {
@@ -80,11 +80,11 @@ fun USaintNavHost(
 
         semesterListScreen(
             navigateToSemesterListDetail = { idx -> navController.navigateToSemesterDetail(idx) },
-            navigateToBack = { navController.popBackStack() },
+            navigateToBack = { navController.navigateUp() },
         )
 
         semesterDetailScreen(
-            navigateToBack = { navController.popBackStack() },
+            navigateToBack = { navController.navigateUp() },
         )
     }
 }


### PR DESCRIPTION
버그번호 : https://github.com/yourssu/Soomsil-USaint-Android/issues/24

popBackStack을 navigateUp으로 바꾸면 고쳐집니다.

참고 : https://youtu.be/y2zLFONuk7c?si=-DaIr7qTYdZdiAIP
