### PR TITLE
fix: systemBar Padding 적용 #48

### DIFF
--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/MainActivity.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/MainActivity.kt
@@ -4,6 +4,9 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.ui.Modifier
 import androidx.navigation.compose.rememberNavController
 import com.yourssu.design.system.compose.YdsTheme
 import com.yourssu.soomsil.usaint.screen.USaintNavHost
@@ -26,6 +29,9 @@ class MainActivity : ComponentActivity() {
                 viewModel.isLoggedIn?.let { isLoggedIn ->
                     USaintNavHost(
                         navController = rememberNavController(),
+                        modifier = Modifier
+                            .navigationBarsPadding()
+                            .statusBarsPadding(),
                         startDestination = if (isLoggedIn) Home else Login
                     )
                 }

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/MainActivity.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/MainActivity.kt
@@ -29,10 +29,10 @@ class MainActivity : ComponentActivity() {
                 viewModel.isLoggedIn?.let { isLoggedIn ->
                     USaintNavHost(
                         navController = rememberNavController(),
+                        startDestination = if (isLoggedIn) Home else Login,
                         modifier = Modifier
                             .navigationBarsPadding()
-                            .statusBarsPadding(),
-                        startDestination = if (isLoggedIn) Home else Login
+                            .statusBarsPadding()
                     )
                 }
             }

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/USaintNavHost.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/USaintNavHost.kt
@@ -24,8 +24,8 @@ import com.yourssu.soomsil.usaint.screen.setting.navigation.settingScreen
 @Composable
 fun USaintNavHost(
     navController: NavHostController,
-    modifier: Modifier = Modifier,
-    startDestination: Any = Login,
+    startDestination: Any,
+    modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
 

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/USaintNavHost.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/USaintNavHost.kt
@@ -2,6 +2,8 @@ package com.yourssu.soomsil.usaint.screen
 
 import android.net.Uri
 import androidx.browser.customtabs.CustomTabsIntent
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -31,7 +33,9 @@ fun USaintNavHost(
 
     NavHost(
         navController = navController,
-        modifier = modifier,
+        modifier = modifier
+            .navigationBarsPadding()
+            .statusBarsPadding(),
         startDestination = startDestination,
     ) {
         loginScreen(

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/USaintNavHost.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/USaintNavHost.kt
@@ -2,8 +2,6 @@ package com.yourssu.soomsil.usaint.screen
 
 import android.net.Uri
 import androidx.browser.customtabs.CustomTabsIntent
-import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -33,9 +31,7 @@ fun USaintNavHost(
 
     NavHost(
         navController = navController,
-        modifier = modifier
-            .navigationBarsPadding()
-            .statusBarsPadding(),
+        modifier = modifier,
         startDestination = startDestination,
     ) {
         loginScreen(


### PR DESCRIPTION
## Summary
> - 안드로이드 디바이스 자체의 navigationBar, statusBar와 같은 systemBar의 Padding이 이루어지지 않아 겹치는 문제가 발생하여  NavigationBar와 statusBar Padding을 추가


## Describe your changes
> - NavHost의 modifier에 padding추가
```
NavHost(
        navController = navController,
        modifier = modifier
            .navigationBarsPadding()
            .statusBarsPadding(),
        startDestination = startDestination,
    )
```
> - 화면 스크린샷
![image](https://github.com/user-attachments/assets/ce6b65d2-f007-4134-8d6d-eb9a085357bd)



## Issue
> - #48 


## To reviewers
> -  저는 기존에도 padding이 적용되어 있어서 에뮬레이터로 테스트를 해봤습니다.
Android 10 (API 29) 이상부터 제스처 네비게이션이 도입되어서 이전과 시스템바 동작방식이 바뀌었기 때문에 API 27로 테스트해봤고 정상적으로 padding이 됐습니다.