### PR TITLE
[feat] material3 마이그레이션 - HomeScreen

### DIFF
--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/HomeScreen.kt
@@ -1,8 +1,9 @@
 package com.yourssu.soomsil.usaint.screen.home
 
 import android.widget.Toast
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -10,41 +11,40 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.KeyboardArrowRight
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.repeatOnLifecycle
-import com.yourssu.design.system.compose.YdsTheme
-import com.yourssu.design.system.compose.atom.ProfileImageView
-import com.yourssu.design.system.compose.base.Icon
-import com.yourssu.design.system.compose.base.YdsScaffold
-import com.yourssu.design.system.compose.base.YdsText
-import com.yourssu.design.system.compose.base.ydsClickable
-import com.yourssu.design.system.compose.component.topbar.SingleTitleTopBar
 import com.yourssu.soomsil.usaint.R
 import com.yourssu.soomsil.usaint.screen.UiEvent
 import com.yourssu.soomsil.usaint.ui.entities.ReportCardSummary
 import com.yourssu.soomsil.usaint.ui.entities.StudentInfo
 import com.yourssu.soomsil.usaint.ui.entities.toCredit
 import com.yourssu.soomsil.usaint.ui.entities.toGrade
-import dev.eatsteak.rusaint.core.Disposable
+import com.yourssu.soomsil.usaint.ui.theme.SoomsilUSaintTheme
 import timber.log.Timber
-import com.yourssu.design.R as YdsR
 
 @Composable
 fun HomeScreen(
@@ -122,21 +122,19 @@ fun HomeScreen(
     onSettingClick: () -> Unit = {},
     onReportCardClick: () -> Unit = {},
 ) {
-    YdsScaffold(
+    Scaffold(
         modifier = modifier,
-        topBar = {
-            SingleTitleTopBar(title = stringResource(id = R.string.saint_title))
-        },
-    ) {
+    ) { padding ->
         PullToRefreshBox(
             isRefreshing = isRefreshing,
             onRefresh = onRefresh,
+            modifier = Modifier.padding(padding)
         ) {
             Column(
                 modifier = Modifier
                     .fillMaxSize()
                     .verticalScroll(rememberScrollState())
-                    .background(YdsTheme.colors.bgSelected)
+                    .background(MaterialTheme.colorScheme.background)
                     .padding(
                         horizontal = 16.dp,
                         vertical = 12.dp,
@@ -173,32 +171,36 @@ fun ActionTitle(
                 horizontal = 16.dp,
                 vertical = 12.dp,
             )
-            .ydsClickable(
-                interactionSource = remember { MutableInteractionSource() },
-                onClick = onClick,
-            ),
+            .clickable(onClick = onClick),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        ProfileImageView(painter = painterResource(id = R.drawable.default_profile_image))
+        Image(
+            modifier = Modifier
+                .size(48.dp)
+                .clip(CircleShape),
+            painter = painterResource(R.drawable.ic_default_profile_image),
+            contentDescription = null,
+        )
         Column(
             modifier = Modifier
                 .weight(1f)
                 .padding(horizontal = 12.dp),
         ) {
-            YdsText(
+            Text(
                 text = subTitle,
-                style = YdsTheme.typography.subTitle3,
-                color = YdsTheme.colors.textSecondary,
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
-            YdsText(
+            Text(
                 text = title,
-                style = YdsTheme.typography.subTitle1,
-                color = YdsTheme.colors.textPrimary,
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.onSurface,
             )
         }
         Icon(
-            id = YdsR.drawable.ic_arrow_right_line,
-            tint = YdsTheme.colors.textPrimary,
+            imageVector = Icons.AutoMirrored.Outlined.KeyboardArrowRight,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurface,
         )
     }
 }
@@ -207,7 +209,7 @@ fun ActionTitle(
 @PreviewLightDark
 @Composable
 private fun HomePreview() {
-    YdsTheme {
+    SoomsilUSaintTheme {
         HomeScreen(
             isRefreshing = false,
             onRefresh = {},
@@ -221,6 +223,18 @@ private fun HomePreview() {
                 earnedCredit = 97.toCredit(),
                 graduateCredit = 133.toCredit(),
             ),
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ActionTitlePreview() {
+    SoomsilUSaintTheme {
+        ActionTitle(
+            title = "asdf",
+            subTitle = "asdfasdf",
+            onClick = {},
         )
     }
 }

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/HomeScreen.kt
@@ -1,36 +1,23 @@
 package com.yourssu.soomsil.usaint.screen.home
 
 import android.widget.Toast
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.outlined.KeyboardArrowRight
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -39,6 +26,8 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.repeatOnLifecycle
 import com.yourssu.soomsil.usaint.R
 import com.yourssu.soomsil.usaint.screen.UiEvent
+import com.yourssu.soomsil.usaint.screen.home.components.ReportCardItem
+import com.yourssu.soomsil.usaint.screen.home.components.StudentInfoItem
 import com.yourssu.soomsil.usaint.ui.entities.ReportCardSummary
 import com.yourssu.soomsil.usaint.ui.entities.StudentInfo
 import com.yourssu.soomsil.usaint.ui.entities.toCredit
@@ -157,55 +146,6 @@ fun HomeScreen(
     }
 }
 
-@Composable
-fun ActionTitle(
-    title: String,
-    subTitle: String,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(
-                horizontal = 16.dp,
-                vertical = 12.dp,
-            )
-            .clickable(onClick = onClick),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Image(
-            modifier = Modifier
-                .size(48.dp)
-                .clip(CircleShape),
-            painter = painterResource(R.drawable.ic_default_profile_image),
-            contentDescription = null,
-        )
-        Column(
-            modifier = Modifier
-                .weight(1f)
-                .padding(horizontal = 12.dp),
-        ) {
-            Text(
-                text = subTitle,
-                style = MaterialTheme.typography.titleSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Text(
-                text = title,
-                style = MaterialTheme.typography.titleLarge,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-        }
-        Icon(
-            imageVector = Icons.AutoMirrored.Outlined.KeyboardArrowRight,
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.onSurface,
-        )
-    }
-}
-
-
 @PreviewLightDark
 @Composable
 private fun HomePreview() {
@@ -223,18 +163,6 @@ private fun HomePreview() {
                 earnedCredit = 97.toCredit(),
                 graduateCredit = 133.toCredit(),
             ),
-        )
-    }
-}
-
-@PreviewLightDark
-@Composable
-private fun ActionTitlePreview() {
-    SoomsilUSaintTheme {
-        ActionTitle(
-            title = "asdf",
-            subTitle = "asdfasdf",
-            onClick = {},
         )
     }
 }

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/HomeScreen.kt
@@ -9,15 +9,19 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -113,6 +117,18 @@ fun HomeScreen(
 ) {
     Scaffold(
         modifier = modifier,
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = {
+                    Text(
+                        text = stringResource(R.string.saint_title),
+                        style = MaterialTheme.typography.headlineSmall.copy(
+                            fontWeight = FontWeight.Bold
+                        ),
+                    )
+                }
+            )
+        }
     ) { padding ->
         PullToRefreshBox(
             isRefreshing = isRefreshing,

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/ReportCardItem.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/ReportCardItem.kt
@@ -9,6 +9,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -17,16 +21,12 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
-import com.yourssu.design.system.compose.YdsTheme
-import com.yourssu.design.system.compose.atom.Divider
-import com.yourssu.design.system.compose.atom.Thickness
-import com.yourssu.design.system.compose.base.Surface
-import com.yourssu.design.system.compose.base.YdsText
 import com.yourssu.soomsil.usaint.R
 import com.yourssu.soomsil.usaint.ui.entities.Grade
 import com.yourssu.soomsil.usaint.ui.entities.ReportCardSummary
 import com.yourssu.soomsil.usaint.ui.entities.toCredit
 import com.yourssu.soomsil.usaint.ui.entities.toGrade
+import com.yourssu.soomsil.usaint.ui.theme.SoomsilUSaintTheme
 
 @Composable
 fun ReportCardItem(
@@ -35,8 +35,7 @@ fun ReportCardItem(
     onReportCardClick: () -> Unit = {},
 ) {
     Surface(
-        rounding = 8.dp,
-        color = YdsTheme.colors.bgNormal,
+        shape = RoundedCornerShape(8.dp),
         modifier = modifier,
     ) {
         Column(
@@ -44,7 +43,7 @@ fun ReportCardItem(
                 .fillMaxWidth()
                 .padding(bottom = 10.dp),
         ) {
-            YdsText(
+            Text(
                 text = stringResource(id = R.string.saint_grade),
                 modifier = Modifier
                     .padding(
@@ -53,8 +52,8 @@ fun ReportCardItem(
                         start = 16.dp,
                         end = 16.dp,
                     ),
-                style = YdsTheme.typography.title3,
-                color = YdsTheme.colors.textPrimary,
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.onSurface,
             )
             ActionTitle(
                 title = stringResource(id = R.string.saint_grade_title),
@@ -81,8 +80,7 @@ private fun ReportCardSummary(
             actualValue = reportCardSummary.gpa.formatToString(),
             maxValue = Grade.Max.formatToString(),
         )
-        Divider(
-            thickness = Thickness.Thin,
+        HorizontalDivider(
             modifier = Modifier.padding(horizontal = 14.dp),
         )
         ReportOutline(
@@ -92,25 +90,25 @@ private fun ReportCardSummary(
         )
 
         // 전체성적 보기 버튼
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(
-                    start = 16.dp,
-                    end = 16.dp,
-                    top = 10.dp,
-                )
-                .clip(RoundedCornerShape(8.dp))
-                .height(40.dp)
-                .background(color = YdsTheme.colors.bgSelected)
-                .clickable(onClick = onReportCardClick),
-            horizontalArrangement = Arrangement.Center,
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            YdsText(
-                text = stringResource(R.string.saint_grade_see_all)
-            )
-        }
+//        Row(
+//            modifier = Modifier
+//                .fillMaxWidth()
+//                .padding(
+//                    start = 16.dp,
+//                    end = 16.dp,
+//                    top = 10.dp,
+//                )
+//                .clip(RoundedCornerShape(8.dp))
+//                .height(40.dp)
+//                .background(color = MaterialTheme.colorScheme.surface)
+//                .clickable(onClick = onReportCardClick),
+//            horizontalArrangement = Arrangement.Center,
+//            verticalAlignment = Alignment.CenterVertically,
+//        ) {
+//            Text(
+//                text = stringResource(R.string.saint_grade_see_all)
+//            )
+//        }
 //        BoxButton(
 //            modifier = Modifier
 //                .fillMaxWidth()
@@ -142,33 +140,33 @@ private fun ReportOutline(
             ),
         verticalAlignment = Alignment.Bottom,
     ) {
-        YdsText(
+        Text(
             text = title,
             modifier = Modifier.weight(1f),
-            style = YdsTheme.typography.body1,
-            color = YdsTheme.colors.textSecondary,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurface,
         )
-        YdsText(
+        Text(
             text = actualValue,
-            style = YdsTheme.typography.subTitle2.copy(
+            style = MaterialTheme.typography.bodyLarge.copy(
                 fontWeight = FontWeight.Bold,
             ),
-            color = YdsTheme.colors.textPointed,
+            color = MaterialTheme.colorScheme.primary,
         )
-        YdsText(
+        Text(
             text = "/",
-            style = YdsTheme.typography.caption0.copy(
+            style = MaterialTheme.typography.bodyMedium.copy(
                 fontWeight = FontWeight.Bold,
             ),
-            color = YdsTheme.colors.textTertiary,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.padding(horizontal = 2.dp),
         )
-        YdsText(
+        Text(
             text = maxValue,
-            style = YdsTheme.typography.caption0.copy(
+            style = MaterialTheme.typography.bodyMedium.copy(
                 fontWeight = FontWeight.Bold,
             ),
-            color = YdsTheme.colors.textTertiary,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
     }
 }
@@ -176,7 +174,7 @@ private fun ReportOutline(
 @PreviewLightDark
 @Composable
 private fun ReportCardItemPreview() {
-    YdsTheme {
+    SoomsilUSaintTheme {
         ReportCardItem(
             reportCardSummary = ReportCardSummary(
                 gpa = 4.22.toGrade(),
@@ -190,7 +188,7 @@ private fun ReportCardItemPreview() {
 @PreviewLightDark
 @Composable
 private fun ReportCardSummaryPreview() {
-    YdsTheme {
+    SoomsilUSaintTheme {
         Surface {
             ReportCardSummary(
                 reportCardSummary = ReportCardSummary(
@@ -206,7 +204,7 @@ private fun ReportCardSummaryPreview() {
 @PreviewLightDark
 @Composable
 private fun ReportOutlinePreview() {
-    YdsTheme {
+    SoomsilUSaintTheme {
         Surface {
             ReportOutline(
                 title = "평균학점",

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/StudentInfoItem.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/StudentInfoItem.kt
@@ -1,27 +1,37 @@
 package com.yourssu.soomsil.usaint.screen.home
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
-import com.yourssu.design.system.compose.YdsTheme
-import com.yourssu.design.system.compose.atom.ProfileImageView
-import com.yourssu.design.system.compose.base.Icon
-import com.yourssu.design.system.compose.base.Surface
-import com.yourssu.design.system.compose.base.YdsText
-import com.yourssu.design.system.compose.base.ydsClickable
 import com.yourssu.soomsil.usaint.R
 import com.yourssu.soomsil.usaint.ui.entities.StudentInfo
-
+import com.yourssu.soomsil.usaint.ui.theme.SoomsilUSaintTheme
 
 @Composable
 fun StudentInfoItem(
@@ -30,49 +40,65 @@ fun StudentInfoItem(
     onProfileClick: () -> Unit = {},
     onSettingClick: () -> Unit = {},
 ) {
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .ydsClickable(onClick = onProfileClick)
-            .padding(
-                horizontal = 16.dp,
-                vertical = 20.dp,
-            ),
-        verticalAlignment = Alignment.CenterVertically,
+    Surface(
+        shape = RoundedCornerShape(4.dp),
+        onClick = onProfileClick,
+        color = Color.Transparent,
+        modifier = modifier,
     ) {
-        ProfileImageView(R.drawable.ic_default_profile_image)
-        Spacer(Modifier.width(12.dp))
-        Column(
-            modifier = Modifier.weight(1f),
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(
+                    horizontal = 16.dp,
+                    vertical = 20.dp,
+                ),
+            verticalAlignment = Alignment.CenterVertically,
         ) {
-            YdsText(
-                text = studentInfo?.name ?: "-",
-                style = YdsTheme.typography.subTitle1.copy(
-                    fontWeight = FontWeight(600),
-                ),
+            Image(
+                modifier = Modifier
+                    .size(48.dp)
+                    .clip(CircleShape),
+                painter = painterResource(R.drawable.ic_default_profile_image),
+                contentDescription = null,
             )
-            YdsText(
-                text = stringResource(
-                    R.string.student_department_and_grade_format,
-                    studentInfo?.department ?: "-",
-                    studentInfo?.grade ?: 0,
-                ),
-                style = YdsTheme.typography.body2,
-                color = YdsTheme.colors.textSecondary,
+            Spacer(Modifier.width(12.dp))
+            Column(
+                modifier = Modifier.weight(1f),
+            ) {
+                Text(
+                    text = studentInfo?.name ?: "-",
+                    style = MaterialTheme.typography.titleLarge.copy(
+                        fontWeight = FontWeight(600),
+                    ),
+                )
+                Text(
+                    text = stringResource(
+                        R.string.student_department_and_grade_format,
+                        studentInfo?.department ?: "-",
+                        studentInfo?.grade ?: 0,
+                    ),
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Spacer(Modifier.width(12.dp))
+            Icon(
+                modifier = Modifier
+                    .clickable(onClick = onSettingClick)
+                    .padding(4.dp)
+                    .size(24.dp),
+                imageVector = Icons.Outlined.Settings,
+                contentDescription = "settings",
             )
         }
-        Spacer(Modifier.width(12.dp))
-        Icon(
-            modifier = Modifier.ydsClickable(onClick = onSettingClick),
-            id = com.yourssu.design.R.drawable.ic_setting_line,
-        )
     }
 }
 
 @PreviewLightDark
 @Composable
 private fun StudentInfoPreview() {
-    YdsTheme {
+    SoomsilUSaintTheme {
         Surface {
             StudentInfoItem(
                 studentInfo = StudentInfo(

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/components/ActionTitle.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/components/ActionTitle.kt
@@ -1,7 +1,6 @@
 package com.yourssu.soomsil.usaint.screen.home.components
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -19,6 +18,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.yourssu.soomsil.usaint.R
@@ -28,7 +28,6 @@ import com.yourssu.soomsil.usaint.ui.theme.SoomsilUSaintTheme
 fun ActionTitle(
     title: String,
     subTitle: String,
-    onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -37,8 +36,7 @@ fun ActionTitle(
             .padding(
                 horizontal = 16.dp,
                 vertical = 12.dp,
-            )
-            .clickable(onClick = onClick),
+            ),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Image(
@@ -55,12 +53,16 @@ fun ActionTitle(
         ) {
             Text(
                 text = subTitle,
-                style = MaterialTheme.typography.titleSmall,
+                style = MaterialTheme.typography.titleSmall.copy(
+                    fontWeight = FontWeight(600),
+                ),
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             Text(
                 text = title,
-                style = MaterialTheme.typography.titleLarge,
+                style = MaterialTheme.typography.titleLarge.copy(
+                    fontWeight = FontWeight(600),
+                ),
                 color = MaterialTheme.colorScheme.onSurface,
             )
         }
@@ -78,9 +80,8 @@ private fun ActionTitlePreview() {
     SoomsilUSaintTheme {
         Surface {
             ActionTitle(
-                title = "asdf",
-                subTitle = "asdfasdf",
-                onClick = {},
+                title = "전체학기",
+                subTitle = "성적 확인하기",
             )
         }
     }

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/components/ActionTitle.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/components/ActionTitle.kt
@@ -1,0 +1,87 @@
+package com.yourssu.soomsil.usaint.screen.home.components
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.KeyboardArrowRight
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import com.yourssu.soomsil.usaint.R
+import com.yourssu.soomsil.usaint.ui.theme.SoomsilUSaintTheme
+
+@Composable
+fun ActionTitle(
+    title: String,
+    subTitle: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(
+                horizontal = 16.dp,
+                vertical = 12.dp,
+            )
+            .clickable(onClick = onClick),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Image(
+            modifier = Modifier
+                .size(48.dp)
+                .clip(CircleShape),
+            painter = painterResource(R.drawable.ic_default_profile_image),
+            contentDescription = null,
+        )
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .padding(horizontal = 12.dp),
+        ) {
+            Text(
+                text = subTitle,
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+        }
+        Icon(
+            imageVector = Icons.AutoMirrored.Outlined.KeyboardArrowRight,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurface,
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ActionTitlePreview() {
+    SoomsilUSaintTheme {
+        Surface {
+            ActionTitle(
+                title = "asdf",
+                subTitle = "asdfasdf",
+                onClick = {},
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/components/ChapelCardItem.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/components/ChapelCardItem.kt
@@ -1,10 +1,10 @@
-package com.yourssu.soomsil.usaint.screen.home
+package com.yourssu.soomsil.usaint.screen.home.components
 
-
-/*@Composable
-private fun GraduationCard(
+/*
+@Composable
+private fun ChapelCardItem(
     isLoggedIn: Boolean,
-    onGraduationCardClick: () -> Unit,
+    onChapelCardClick: () -> Unit,
 ) {
     Surface(
         rounding = 8.dp,
@@ -16,7 +16,7 @@ private fun GraduationCard(
                 .padding(bottom = 10.dp),
         ) {
             YdsText(
-                text = stringResource(id = R.string.saint_graduation),
+                text = stringResource(id = R.string.saint_chapel),
                 modifier = Modifier
                     .padding(
                         top = 20.dp,
@@ -30,9 +30,16 @@ private fun GraduationCard(
                 ),
             )
             ActionTitle(
-                title = stringResource(id = R.string.saint_graduation_title),
-                subTitle = stringResource(id = R.string.saint_graduation_subtitle),
-                onClick = onGraduationCardClick,
+                title = stringResource(id = R.string.saint_chapel_seat_title),
+                subTitle = stringResource(id = R.string.saint_chapel_seat_subtitle),
+                onClick = onChapelCardClick,
+                enable = false,
+                enable = isLoggedIn,
+            )
+            ActionTitle(
+                title = stringResource(id = R.string.saint_chapel_attendance_title),
+                subTitle = stringResource(id = R.string.saint_chapel_attendance_subtitle),
+                onClick = onChapelCardClick,
                 enable = false,
                 enable = isLoggedIn,
             )

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/components/GraduationCardItem.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/components/GraduationCardItem.kt
@@ -1,10 +1,10 @@
-package com.yourssu.soomsil.usaint.screen.home
+package com.yourssu.soomsil.usaint.screen.home.components
 
-/*
-@Composable
-private fun ChapelCardItem(
+
+/*@Composable
+private fun GraduationCard(
     isLoggedIn: Boolean,
-    onChapelCardClick: () -> Unit,
+    onGraduationCardClick: () -> Unit,
 ) {
     Surface(
         rounding = 8.dp,
@@ -16,7 +16,7 @@ private fun ChapelCardItem(
                 .padding(bottom = 10.dp),
         ) {
             YdsText(
-                text = stringResource(id = R.string.saint_chapel),
+                text = stringResource(id = R.string.saint_graduation),
                 modifier = Modifier
                     .padding(
                         top = 20.dp,
@@ -30,16 +30,9 @@ private fun ChapelCardItem(
                 ),
             )
             ActionTitle(
-                title = stringResource(id = R.string.saint_chapel_seat_title),
-                subTitle = stringResource(id = R.string.saint_chapel_seat_subtitle),
-                onClick = onChapelCardClick,
-                enable = false,
-                enable = isLoggedIn,
-            )
-            ActionTitle(
-                title = stringResource(id = R.string.saint_chapel_attendance_title),
-                subTitle = stringResource(id = R.string.saint_chapel_attendance_subtitle),
-                onClick = onChapelCardClick,
+                title = stringResource(id = R.string.saint_graduation_title),
+                subTitle = stringResource(id = R.string.saint_graduation_subtitle),
+                onClick = onGraduationCardClick,
                 enable = false,
                 enable = isLoggedIn,
             )

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/components/ReportCardItem.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/components/ReportCardItem.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -29,9 +29,9 @@ fun ReportCardItem(
     modifier: Modifier = Modifier,
     onReportCardClick: () -> Unit = {},
 ) {
-    Surface(
-        shape = RoundedCornerShape(8.dp),
+    ElevatedCard(
         modifier = modifier,
+        onClick = onReportCardClick,
     ) {
         Column(
             modifier = Modifier
@@ -47,13 +47,14 @@ fun ReportCardItem(
                         start = 16.dp,
                         end = 16.dp,
                     ),
-                style = MaterialTheme.typography.titleLarge,
+                style = MaterialTheme.typography.titleLarge.copy(
+                    fontWeight = FontWeight.Bold
+                ),
                 color = MaterialTheme.colorScheme.onSurface,
             )
             ActionTitle(
                 title = stringResource(id = R.string.saint_grade_title),
                 subTitle = stringResource(id = R.string.saint_grade_subtitle),
-                onClick = onReportCardClick,
             )
             ReportCardSummary(
                 reportCardSummary = reportCardSummary,

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/components/ReportCardItem.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/components/ReportCardItem.kt
@@ -1,12 +1,8 @@
-package com.yourssu.soomsil.usaint.screen.home
+package com.yourssu.soomsil.usaint.screen.home.components
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
@@ -16,7 +12,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.PreviewLightDark

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/components/StudentInfoItem.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/components/StudentInfoItem.kt
@@ -1,8 +1,7 @@
-package com.yourssu.soomsil.usaint.screen.home
+package com.yourssu.soomsil.usaint.screen.home.components
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -19,7 +18,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/components/StudentInfoItem.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/components/StudentInfoItem.kt
@@ -1,7 +1,6 @@
 package com.yourssu.soomsil.usaint.screen.home.components
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -10,10 +9,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -21,7 +21,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -38,11 +37,9 @@ fun StudentInfoItem(
     onProfileClick: () -> Unit = {},
     onSettingClick: () -> Unit = {},
 ) {
-    Surface(
-        shape = RoundedCornerShape(4.dp),
-        onClick = onProfileClick,
-        color = Color.Transparent,
+    ElevatedCard(
         modifier = modifier,
+        onClick = onProfileClick,
     ) {
         Row(
             modifier = Modifier
@@ -81,14 +78,17 @@ fun StudentInfoItem(
                 )
             }
             Spacer(Modifier.width(12.dp))
-            Icon(
-                modifier = Modifier
-                    .clickable(onClick = onSettingClick)
-                    .padding(4.dp)
-                    .size(24.dp),
-                imageVector = Icons.Outlined.Settings,
-                contentDescription = "settings",
-            )
+            IconButton(
+                onClick = onSettingClick,
+            ) {
+                Icon(
+                    modifier = Modifier
+                        .padding(4.dp)
+                        .size(24.dp),
+                    imageVector = Icons.Outlined.Settings,
+                    contentDescription = "settings",
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 홈화면(HomeScreen)의 UI 디자인을 material3로 변경했습니다.

![image](https://github.com/user-attachments/assets/ca6b50a4-730c-4a0e-bad5-7b04f2c228a6)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
