### PR TITLE
[fix] ndk ABI 필터 삭제

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,7 +19,7 @@ android {
         applicationId = "com.yourssu.soomsil.usaint"
         minSdk = 26
         targetSdk = 35
-        versionCode = 9
+        versionCode = 11
         versionName = "0.2.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
@@ -46,11 +46,6 @@ android {
     }
     room {
         schemaDirectory("$projectDir/schemas")
-    }
-    defaultConfig {
-        ndk {
-            abiFilters += setOf("x86_64")
-        }
     }
 }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
X

테스트할 때 ABI 필터를 x86_64로 명시적으로 지정해준 것을 해제하지 않아 x86_64 기기만 지원되는 문제가 있었습니다.
필터를 지정하지 않으면 빌드 시 필터를 자동으로 처리해주기 때문에 삭제했습니다.