### PR TITLE
[feat] Trend Wave 버튼 삭제

### DIFF
--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/HomeScreen.kt
@@ -1,6 +1,5 @@
 package com.yourssu.soomsil.usaint.screen.home
 
-import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -17,14 +16,17 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
@@ -36,6 +38,7 @@ import com.yourssu.soomsil.usaint.screen.home.components.ActionTitleItem
 import com.yourssu.soomsil.usaint.screen.home.components.ReportCardItem
 import com.yourssu.soomsil.usaint.screen.home.components.StudentDataItem
 import com.yourssu.soomsil.usaint.ui.theme.SoomsilUSaintTheme
+import kotlinx.coroutines.launch
 
 @Composable
 fun HomeScreen(
@@ -45,6 +48,7 @@ fun HomeScreen(
     onReportCardClick: () -> Unit = {},
     viewModel: HomeViewModel = hiltViewModel(),
 ) {
+    val snackbarHostState = remember { SnackbarHostState() }
     val homeUiState by viewModel.homeUiState.collectAsStateWithLifecycle()
 
     HomeScreen(
@@ -56,6 +60,7 @@ fun HomeScreen(
         onSettingClick = onSettingClick,
         onReportCardClick = onReportCardClick,
         modifier = modifier,
+        snackbarHostState = snackbarHostState,
     )
 }
 
@@ -67,17 +72,19 @@ private fun HomeScreen(
     onRefresh: () -> Unit,
     homeUiState: HomeUiState,
     modifier: Modifier = Modifier,
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     onProfileClick: () -> Unit = {},
     onSettingClick: () -> Unit = {},
     onReportCardClick: () -> Unit = {},
 ) {
     // 임시
-    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
 
     val isHomeLoading = homeUiState is HomeUiState.Loading
 
     Scaffold(
         modifier = modifier,
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
         topBar = {
             Box {
                 TopAppBar(title = { Text(text = "유세인트") })
@@ -143,7 +150,9 @@ private fun HomeScreen(
                     ActionTitleItem(
                         title = "이번 학기 성적 확인",
                         onClick = {
-                            Toast.makeText(context, "서비스 예정입니다.", Toast.LENGTH_SHORT).show()
+                            scope.launch {
+                                snackbarHostState.showSnackbar("준비 중입니다.")
+                            }
                         },
                     )
                 }

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/HomeScreen.kt
@@ -1,12 +1,9 @@
 package com.yourssu.soomsil.usaint.screen.home
 
-import android.content.Intent
 import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
@@ -15,12 +12,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.outlined.KeyboardArrowRight
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -31,12 +24,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
-import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.yourssu.soomsil.usaint.core.model.ReportCardSummaryData
@@ -137,36 +128,6 @@ private fun HomeScreen(
                     onProfileClick = onProfileClick,
                     onSettingClick = onSettingClick,
                 )
-
-                Spacer(Modifier.height(8.dp))
-                ElevatedCard(
-                    onClick = {
-                        val intent = Intent(
-                            Intent.ACTION_VIEW,
-                            "https://trendwave-one.vercel.app/".toUri()
-                        )
-                        context.startActivity(intent)
-                    }
-                ) {
-                    Row(
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 16.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text(
-                            "\"TREND WAVE 2025\" 티켓 받으러 가기",
-                            modifier = Modifier
-                                .weight(1f)
-                                .padding(vertical = 16.dp)
-                        )
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Outlined.KeyboardArrowRight,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onSurface,
-                        )
-                    }
-                }
 
                 Spacer(Modifier.height(8.dp))
                 Text(


### PR DESCRIPTION
## #️⃣연관된 이슈
X

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 이번 학기 성적 확인을 클릭시 토스트 대신 Snackbar를 띄우도록 수정했습니다.
- Trend Wave 이벤트 기간이 끝남에 따라 홈 화면에서 해당 버튼을 삭제했습니다.

|AS IS|TO BE|
|:-:|:-:|
|![image](https://github.com/user-attachments/assets/694d1b37-3bef-4bc8-aa9d-ec06ef52fc3b)|![image](https://github.com/user-attachments/assets/6e0b508c-4888-48bb-8414-2ec17d686811)|


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
