### PR TITLE
[feat] systembar 다크모드 색 통일

### DIFF
--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/MainActivity.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/MainActivity.kt
@@ -5,10 +5,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
-import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.yourssu.soomsil.usaint.screen.home.navigation.Home
 import com.yourssu.soomsil.usaint.screen.login.navigation.Login
@@ -33,9 +30,6 @@ class MainActivity : ComponentActivity() {
                     val credentialExist = mainUiState is MainUiState.Success
                     USaintApp(
                         startDestination = if (credentialExist) Home else Login,
-                        modifier = Modifier
-                            .navigationBarsPadding()
-                            .statusBarsPadding()
                     )
                 }
             }

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/navigation/USaintNavHost.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/navigation/USaintNavHost.kt
@@ -15,6 +15,7 @@ import com.yourssu.soomsil.usaint.screen.login.navigation.navigateToLogin
 import com.yourssu.soomsil.usaint.screen.reportcard.navigation.reportCardScreen
 import com.yourssu.soomsil.usaint.screen.setting.navigation.navigateToSetting
 import com.yourssu.soomsil.usaint.screen.setting.navigation.settingScreen
+import androidx.core.net.toUri
 
 @Composable
 fun USaintNavHost(
@@ -50,7 +51,7 @@ fun USaintNavHost(
             },
             navigateToWebView = { url ->
                 CustomTabsIntent.Builder().build().also {
-                    it.launchUrl(context, Uri.parse(url))
+                    it.launchUrl(context, url.toUri())
                 }
             },
             navigateToLogin = {

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/ui/USaintApp.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/ui/USaintApp.kt
@@ -1,5 +1,6 @@
 package com.yourssu.soomsil.usaint.ui
 
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
@@ -58,7 +59,9 @@ fun USaintApp(
         USaintNavHost(
             navController = navController,
             startDestination = startDestination,
-            modifier = Modifier.padding(padding),
+            modifier = Modifier
+                .padding(padding)
+                .consumeWindowInsets(padding),
         )
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

PR을 자꾸 열었다 닫았다 한 이유는...
리베이스를 했는데도 자꾸 이전 것도 나오길래 이유를 모르겠어서 이것저것 해보다가
알고보니 develop을 땡겨와야하는데 main을 땡겨오고 있었더라구요... 그래서 좀 꼬여서 아싸리 새로 올렸습니다....ㅠㅠ

Android15부터
```
enableEdgeToEdge()
```
을 통해 화면을 `SystemBar` 까지 확장하는 걸 강제하도록 변경되었는데
지난 번에 `SystemBar` 패딩을 하면서 화면이 그려지는 범위를 SystamBar를 제외한 화면으로 지정하게 됨에 따라 
statusbar 와 navigationbar 의 색은 테마를 따라가지 않는 것 같습니다.

```
window.statusBarColor = colorScheme.surface.toArgb()
```
이런 방식을 통해 의도적으로 조정할 수있지만

현재 `enableEdgeToEdge()` 가 도입되면서 deprecated되어서 이를 사용하는 게 좋은 방법같지는 않습니다.
지난번에 패딩을 넣긴 했지만 현재 안드로이드에서는 화면을 SystemBar까지 확장하는 것을 지향하는 것 같아 systembar padding을 없애는 것으로 결정하였습니다.

systembar padding을 지우니까 기존에 패딩이 적용된 것을 기준으로 그려지던 UI가 navigationbar padding이 사라지니 그만큼 아래로 내려오는 문제가 발생했습니다.

확인해보니 각각의 Screen에서 추가적으로 `Scaffold`가 호출되고 거기서 `padding`이 또 사용되서 중복 적용되다보니 추가로 내려오더라구요.
그래서 동일한 padding이 중복 적용되지 않도록 
```
USaintNavHost(
            navController = navController,
            startDestination = startDestination,
            modifier = Modifier
                .padding(padding)
                .consumeWindowInsets(padding),
)
```
`consumeWindowInsets(padding)`로 중복패딩 방지를 해줬습니다.

1.기존
<img src = "https://github.com/user-attachments/assets/0874f559-a5c9-434c-a415-13dbf4150158" width = "300">
2.systambar padding 제거
<img src = "https://github.com/user-attachments/assets/24bcf3f3-00df-467a-84ba-93b02c8e5ea7" width = "300">
3.consumeWindowInsets 적용
<img src ="https://github.com/user-attachments/assets/7fcbe40e-5969-4905-bed2-e9fdfa632207" width = "300">

## 💬리뷰 요구사항(선택)
+ 홈과 성적 탭의 `Scaffold`가 동일한 내용으로 탑바의 이름만 다르게 적용되는데 아예 최상위 `Scaffold`에서 `destination.name`이런식으로 별도 인자를 사용해서 `TopBar`를  처리하면 어떨까요?
이렇게 하면 코드 중복을 줄일 수 있고 개인적으로 `consumeWindowInsets(padding)`는 뒷수습을 하는 느낌이라 되도록 지양하는 게 좋아 보입니다.
예를 들어 특정 상황에서는 정말로 동일한 패딩이 중복으로 사용되는 게 필요할 수도 있는데 이렇게 할 경우 강제로 사용하지 못하는 문제가 발생할 가능성이 있다고 생각합니다.