### PR TITLE
[feat] 현재 학기 판단 로직 추가 및 수동 설정 기능

### DIFF
--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/core/model/UserData.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/core/model/UserData.kt
@@ -1,6 +1,10 @@
 package com.yourssu.soomsil.usaint.core.model
 
+import com.yourssu.soomsil.usaint.core.types.SemesterType
+
 data class UserData(
     val notificationEnabled: Boolean,
     val includeSeasonalSemester: Boolean,
+    val isCurrentSemesterSpecified: Boolean,
+    val specifiedCurrentSemester: Pair<Int, SemesterType>? = null,
 )

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/repository/UserDataRepository.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/repository/UserDataRepository.kt
@@ -1,6 +1,7 @@
 package com.yourssu.soomsil.usaint.data.repository
 
 import com.yourssu.soomsil.usaint.core.model.UserData
+import com.yourssu.soomsil.usaint.core.types.SemesterType
 import com.yourssu.soomsil.usaint.data.source.local.datastore.UserPreferencesDataSource
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
@@ -15,6 +16,12 @@ class UserDataRepository @Inject constructor(
 
     suspend fun setIncludeSeasonalSemester(include: Boolean) =
         userPreferencesDataSource.setIncludeSeasonalSemester(include)
+
+    suspend fun setCurrentSemesterSpecified(year: Int, semester: SemesterType) =
+        userPreferencesDataSource.setCurrentSemesterSpecified(year, semester)
+
+    suspend fun setCurrentSemesterUnspecified() =
+        userPreferencesDataSource.setCurrentSemesterUnspecified()
 
     suspend fun clear() = userPreferencesDataSource.clear()
 }

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/source/local/datastore/UserPreferencesDataSource.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/source/local/datastore/UserPreferencesDataSource.kt
@@ -2,6 +2,7 @@ package com.yourssu.soomsil.usaint.data.source.local.datastore
 
 import androidx.datastore.core.DataStore
 import com.yourssu.soomsil.usaint.core.model.UserData
+import com.yourssu.soomsil.usaint.core.types.SemesterType
 import com.yourssu.soomsil.usaint.proto.UserPreferences
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -17,15 +18,19 @@ class UserPreferencesDataSource @Inject constructor(
             UserData(
                 notificationEnabled = it.notificationEnabled,
                 includeSeasonalSemester = it.includeSeasonalSemester,
+                isCurrentSemesterSpecified = it.isCurrentSemesterSpecified,
+                specifiedCurrentSemester = try {
+                    Pair(it.specifiedCurrentYear, enumValueOf(it.specifiedCurrentSemester))
+                } catch (e: Exception) {
+                    null
+                },
             )
         }
 
     suspend fun setNotificationEnabled(enable: Boolean) {
         try {
             userPreferences.updateData {
-                it.copy {
-                    setNotificationEnabled(enable)
-                }
+                it.copy { setNotificationEnabled(enable) }
             }
         } catch (e: IOException) {
             Timber.e("Failed to update user preferences", e)
@@ -35,9 +40,31 @@ class UserPreferencesDataSource @Inject constructor(
     suspend fun setIncludeSeasonalSemester(include: Boolean) {
         try {
             userPreferences.updateData {
+                it.copy { setIncludeSeasonalSemester(include) }
+            }
+        } catch (e: IOException) {
+            Timber.e("Failed to update user preferences", e)
+        }
+    }
+
+    suspend fun setCurrentSemesterSpecified(year: Int, semester: SemesterType) {
+        try {
+            userPreferences.updateData {
                 it.copy {
-                    setIncludeSeasonalSemester(include)
+                    setIsCurrentSemesterSpecified(true)
+                    setSpecifiedCurrentYear(year)
+                    setSpecifiedCurrentSemester(semester.name)
                 }
+            }
+        } catch (e: IOException) {
+            Timber.e("Failed to update user preferences", e)
+        }
+    }
+
+    suspend fun setCurrentSemesterUnspecified() {
+        try {
+            userPreferences.updateData {
+                it.copy { setIsCurrentSemesterSpecified(false) }
             }
         } catch (e: IOException) {
             Timber.e("Failed to update user preferences", e)

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/domain/usecase/GetCurrentSemesterUseCase.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/domain/usecase/GetCurrentSemesterUseCase.kt
@@ -1,11 +1,21 @@
 package com.yourssu.soomsil.usaint.domain.usecase
 
 import com.yourssu.soomsil.usaint.core.types.SemesterType
+import com.yourssu.soomsil.usaint.data.source.local.datastore.UserPreferencesDataSource
+import kotlinx.coroutines.flow.first
 import java.time.LocalDate
 import javax.inject.Inject
 
-class GetCurrentSemesterUseCase @Inject constructor() {
-    operator fun invoke(): Pair<Int, SemesterType>? {
+class GetCurrentSemesterUseCase @Inject constructor(
+    private val userPreferencesDataSource: UserPreferencesDataSource,
+) {
+    suspend operator fun invoke(): Pair<Int, SemesterType>? {
+        val userData = userPreferencesDataSource.userData.first()
+        if (userData.isCurrentSemesterSpecified) return userData.specifiedCurrentSemester
+        return default()
+    }
+
+    fun default(): Pair<Int, SemesterType>? {
         val now = LocalDate.now()
         val year = now.year
 

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/domain/usecase/GetCurrentSemesterUseCase.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/domain/usecase/GetCurrentSemesterUseCase.kt
@@ -1,0 +1,25 @@
+package com.yourssu.soomsil.usaint.domain.usecase
+
+import com.yourssu.soomsil.usaint.core.types.SemesterType
+import java.time.LocalDate
+import javax.inject.Inject
+
+class GetCurrentSemesterUseCase @Inject constructor() {
+    operator fun invoke(): SemesterType? {
+        val now = LocalDate.now()
+        val year = now.year
+
+        // 1학기: X년도 6/8 ~ X년도 7/7
+        // 여름학기: X년도 7/11 ~ X년도 7/25
+        // 2학기: X년도 12/8 ~ X+1년도 1/7
+        // 겨울학기: X+1년도 1/11 ~ X+1년도 1/26
+        return when (now) {
+            in LocalDate.of(year, 6, 8)..LocalDate.of(year, 7, 7) -> SemesterType.One
+            in LocalDate.of(year, 7, 11)..LocalDate.of(year, 7, 25) -> SemesterType.Summer
+            in LocalDate.of(year, 12, 8)..LocalDate.of(year, 12, 31) -> SemesterType.Two
+            in LocalDate.of(year, 1, 1)..LocalDate.of(year, 1, 7) -> SemesterType.Two
+            in LocalDate.of(year, 1, 11)..LocalDate.of(year, 1, 26) -> SemesterType.Winter
+            else -> null
+        }
+    }
+}

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/domain/usecase/GetCurrentSemesterUseCase.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/domain/usecase/GetCurrentSemesterUseCase.kt
@@ -5,20 +5,32 @@ import java.time.LocalDate
 import javax.inject.Inject
 
 class GetCurrentSemesterUseCase @Inject constructor() {
-    operator fun invoke(): SemesterType? {
+    operator fun invoke(): Pair<Int, SemesterType>? {
         val now = LocalDate.now()
         val year = now.year
 
-        // 1학기: X년도 6/8 ~ X년도 7/7
-        // 여름학기: X년도 7/11 ~ X년도 7/25
-        // 2학기: X년도 12/8 ~ X+1년도 1/7
-        // 겨울학기: X+1년도 1/11 ~ X+1년도 1/26
+        // 2025년도 학기 개강 ~ 종강
+        // https://ssu.ac.kr/%ED%95%99%EC%82%AC/%ED%95%99%EC%82%AC%EC%9D%BC%EC%A0%95/
+        // 1학기: 3/4 ~ 6/23
+        // 여름학기: 6/24 ~ 7/14
+        // 2학기: 9/1 ~ 12/20
+        // 겨울학기: 12/22 ~ 1/15
         return when (now) {
-            in LocalDate.of(year, 6, 8)..LocalDate.of(year, 7, 7) -> SemesterType.One
-            in LocalDate.of(year, 7, 11)..LocalDate.of(year, 7, 25) -> SemesterType.Summer
-            in LocalDate.of(year, 12, 8)..LocalDate.of(year, 12, 31) -> SemesterType.Two
-            in LocalDate.of(year, 1, 1)..LocalDate.of(year, 1, 7) -> SemesterType.Two
-            in LocalDate.of(year, 1, 11)..LocalDate.of(year, 1, 26) -> SemesterType.Winter
+            in LocalDate.of(year, 3, 4)..LocalDate.of(year, 6, 23) ->
+                Pair(year, SemesterType.One)
+
+            in LocalDate.of(year, 6, 24)..LocalDate.of(year, 7, 14) ->
+                Pair(year, SemesterType.Summer)
+
+            in LocalDate.of(year, 9, 1)..LocalDate.of(year, 12, 20) ->
+                Pair(year, SemesterType.Two)
+
+            in LocalDate.of(year, 12, 22)..LocalDate.of(year, 12, 31) ->
+                Pair(year, SemesterType.Winter)
+
+            in LocalDate.of(year, 1, 1)..LocalDate.of(year, 1, 15) ->
+                Pair(year - 1, SemesterType.Winter)
+
             else -> null
         }
     }

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/setting/SettingScreen.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/setting/SettingScreen.kt
@@ -355,7 +355,7 @@ private fun CurrentSemesterSettingDialog(
             shape = MaterialTheme.shapes.large,
             tonalElevation = AlertDialogDefaults.TonalElevation,
         ) {
-            Column(Modifier.padding(8.dp)) {
+            Column(Modifier.padding(24.dp)) {
                 OutlinedTextField(
                     value = yearText,
                     onValueChange = { yearText = it },

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/setting/SettingScreen.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/setting/SettingScreen.kt
@@ -172,6 +172,29 @@ fun SettingScreen(
                 modifier = Modifier
                     .fillMaxWidth()
                     .clickable {
+                        if (settingUiState is SettingUiState.UserEditableSettings)
+                            onAutoFetchToggleChange(!settingUiState.autoFetchEnabled)
+                    },
+                headlineContent = { Text(text = "최신 학사 정보 자동으로 불러오기") },
+                trailingContent = {
+                    when (settingUiState) {
+                        is SettingUiState.UserEditableSettings -> {
+                            Switch(
+                                checked = settingUiState.autoFetchEnabled,
+                                onCheckedChange = onAutoFetchToggleChange,
+                            )
+                        }
+
+                        is SettingUiState.Loading -> {
+                            CircularProgressIndicator()
+                        }
+                    }
+                }
+            )
+            ListItem(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable {
                         if (settingUiState is SettingUiState.UserEditableSettings) {
                             if (settingUiState.currentSemesterSpecified) {
                                 onUnspecifiedCurrentSemester()
@@ -208,31 +231,6 @@ fun SettingScreen(
                                         showCurrentSemesterSettingDialog = true
                                     }
                                 },
-                            )
-                        }
-
-                        is SettingUiState.Loading -> {
-                            CircularProgressIndicator()
-                        }
-                    }
-                }
-            )
-
-            Spacer(Modifier.height(16.dp))
-            ListItem(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable {
-                        if (settingUiState is SettingUiState.UserEditableSettings)
-                            onAutoFetchToggleChange(!settingUiState.autoFetchEnabled)
-                    },
-                headlineContent = { Text(text = "최신 학사 정보 자동으로 불러오기") },
-                trailingContent = {
-                    when (settingUiState) {
-                        is SettingUiState.UserEditableSettings -> {
-                            Switch(
-                                checked = settingUiState.autoFetchEnabled,
-                                onCheckedChange = onAutoFetchToggleChange,
                             )
                         }
 
@@ -371,6 +369,7 @@ private fun CurrentSemesterSettingDialog(
 ) {
     var yearText by rememberSaveable { mutableStateOf(year.toString()) }
     var selectedSemester by rememberSaveable { mutableStateOf(semester) }
+    var confirmButtonEnabled by rememberSaveable { mutableStateOf(true) }
 
     BasicAlertDialog(
         onDismissRequest = onDismissRequest,
@@ -385,7 +384,10 @@ private fun CurrentSemesterSettingDialog(
             Column(Modifier.padding(24.dp)) {
                 OutlinedTextField(
                     value = yearText,
-                    onValueChange = { yearText = it },
+                    onValueChange = {
+                        yearText = it
+                        confirmButtonEnabled = yearText.toIntOrNull() != null
+                    },
                     keyboardOptions = KeyboardOptions(
                         keyboardType = KeyboardType.Number,
                         imeAction = ImeAction.Next,
@@ -417,7 +419,10 @@ private fun CurrentSemesterSettingDialog(
                     TextButton(onClick = onDismissRequest) {
                         Text("취소")
                     }
-                    TextButton(onClick = { onConfirmClick(yearText.toInt(), selectedSemester) }) {
+                    TextButton(
+                        onClick = { onConfirmClick(yearText.toInt(), selectedSemester) },
+                        enabled = confirmButtonEnabled,
+                    ) {
                         Text("확인")
                     }
                 }

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/setting/SettingScreen.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/setting/SettingScreen.kt
@@ -9,22 +9,34 @@ import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.KeyboardArrowLeft
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.AlertDialogDefaults
+import androidx.compose.material3.BasicAlertDialog
 import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -33,15 +45,19 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.yourssu.soomsil.usaint.BuildConfig
 import com.yourssu.soomsil.usaint.R
+import com.yourssu.soomsil.usaint.core.types.SemesterType
 import com.yourssu.soomsil.usaint.ui.theme.SoomsilUSaintTheme
 import com.yourssu.soomsil.usaint.util.NotificationUtil
 
@@ -104,6 +120,8 @@ fun SettingScreen(
                 }
             }
         },
+        onSpecifiedCurrentSemester = viewModel::specifyCurrentSemester,
+        onUnspecifiedCurrentSemester = viewModel::unspecifiedCurrentSemester,
         onLogout = {
             viewModel.logout()
             navigateToLogin()
@@ -115,14 +133,17 @@ fun SettingScreen(
 @Composable
 fun SettingScreen(
     settingUiState: SettingUiState,
-    onNotificationToggleChange: (Boolean) -> Unit,
+    @Suppress("unused") onNotificationToggleChange: (Boolean) -> Unit,
+    onSpecifiedCurrentSemester: (year: Int, semester: SemesterType) -> Unit,
+    onUnspecifiedCurrentSemester: () -> Unit,
     modifier: Modifier = Modifier,
     onBackClick: () -> Unit = {},
     onLogout: () -> Unit = {},
     onClickTermsOfService: () -> Unit = {},
     onClickTermsOfPrivacy: () -> Unit = {},
 ) {
-    var showDialog by rememberSaveable { mutableStateOf(false) }
+    var showCurrentSemesterSettingDialog by rememberSaveable { mutableStateOf(false) }
+    var showLogoutDialog by rememberSaveable { mutableStateOf(false) }
 
     Scaffold(
         modifier = modifier,
@@ -144,6 +165,57 @@ fun SettingScreen(
         Column(
             modifier = Modifier.padding(innerPadding)
         ) {
+            Spacer(Modifier.height(8.dp))
+            ListItem(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable {
+                        if (settingUiState is SettingUiState.UserEditableSettings) {
+                            if (settingUiState.currentSemesterSpecified) {
+                                onUnspecifiedCurrentSemester()
+                            } else {
+                                showCurrentSemesterSettingDialog = true
+                            }
+                        }
+                    },
+                headlineContent = { Text(text = "현재 학기 설정") },
+                supportingContent = {
+                    if (settingUiState is SettingUiState.UserEditableSettings) {
+                        val semesterStr =
+                            settingUiState.specifiedCurrentSemester?.let { (year, semester) ->
+                                "${year}년 ${semester.kor}학기"
+                            } ?: "-"
+                        Text(
+                            text = if (settingUiState.currentSemesterSpecified) {
+                                "설정된 학기: $semesterStr"
+                            } else {
+                                "현재 학기를 수동으로 설정할 수 있습니다.\n감지된 현재 학기: $semesterStr"
+                            }
+                        )
+                    }
+                },
+                trailingContent = {
+                    when (settingUiState) {
+                        is SettingUiState.UserEditableSettings -> {
+                            Switch(
+                                checked = settingUiState.currentSemesterSpecified,
+                                onCheckedChange = {
+                                    if (settingUiState.currentSemesterSpecified) {
+                                        onUnspecifiedCurrentSemester()
+                                    } else {
+                                        showCurrentSemesterSettingDialog = true
+                                    }
+                                },
+                            )
+                        }
+
+                        is SettingUiState.Loading -> {
+                            CircularProgressIndicator()
+                        }
+                    }
+                }
+            )
+
             Spacer(Modifier.height(16.dp))
             Text(
                 modifier = Modifier.padding(horizontal = 16.dp),
@@ -154,7 +226,7 @@ fun SettingScreen(
             ListItem(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .clickable { showDialog = true },
+                    .clickable { showLogoutDialog = true },
                 headlineContent = { Text(text = "로그아웃") }
             )
 
@@ -226,37 +298,139 @@ fun SettingScreen(
             )
         }
 
-        if (showDialog) {
+        if (showLogoutDialog) {
             AlertDialog(
-                onDismissRequest = { showDialog = false },
+                onDismissRequest = { showLogoutDialog = false },
                 title = { Text(text = "로그아웃") },
                 text = { Text(text = "로그아웃 하시겠습니까? 모든 데이터가 삭제됩니다.") },
                 confirmButton = {
                     TextButton(onClick = {
                         onLogout()
-                        showDialog = false
+                        showLogoutDialog = false
                     }) {
                         Text(text = "로그아웃")
                     }
                 },
                 dismissButton = {
-                    TextButton(onClick = { showDialog = false }) {
+                    TextButton(onClick = { showLogoutDialog = false }) {
                         Text(text = "취소")
                     }
                 },
             )
+        }
+
+        if (showCurrentSemesterSettingDialog && settingUiState is SettingUiState.UserEditableSettings) {
+            CurrentSemesterSettingDialog(
+                year = settingUiState.specifiedCurrentSemester?.first ?: 2025,
+                semester = settingUiState.specifiedCurrentSemester?.second ?: SemesterType.One,
+                onConfirmClick = { year, semester ->
+                    onSpecifiedCurrentSemester(year, semester)
+                    showCurrentSemesterSettingDialog = false
+                },
+                onDismissRequest = { showCurrentSemesterSettingDialog = false },
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun CurrentSemesterSettingDialog(
+    year: Int,
+    semester: SemesterType,
+    onConfirmClick: (year: Int, semester: SemesterType) -> Unit,
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var yearText by rememberSaveable { mutableStateOf(year.toString()) }
+    var selectedSemester by rememberSaveable { mutableStateOf(semester) }
+
+    BasicAlertDialog(
+        onDismissRequest = onDismissRequest,
+    ) {
+        Surface(
+            modifier = modifier
+                .wrapContentWidth()
+                .wrapContentHeight(),
+            shape = MaterialTheme.shapes.large,
+            tonalElevation = AlertDialogDefaults.TonalElevation,
+        ) {
+            Column(Modifier.padding(8.dp)) {
+                OutlinedTextField(
+                    value = yearText,
+                    onValueChange = { yearText = it },
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = KeyboardType.Number,
+                        imeAction = ImeAction.Next,
+                    ),
+                    label = { Text(text = "연도") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+
+                SemesterType.entries.forEach { semester ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { selectedSemester = semester },
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        RadioButton(
+                            selected = semester == selectedSemester,
+                            onClick = { selectedSemester = semester },
+                        )
+                        Text(text = "${semester.kor}학기")
+                    }
+                }
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                ) {
+                    TextButton(onClick = onDismissRequest) {
+                        Text("취소")
+                    }
+                    TextButton(onClick = { onConfirmClick(yearText.toInt(), selectedSemester) }) {
+                        Text("확인")
+                    }
+                }
+            }
         }
     }
 }
 
 @PreviewLightDark
 @Composable
-fun PreviewSettingScreen() {
+fun SettingScreenPreview() {
     var notiToggle by remember { mutableStateOf(false) }
+    var currentSemesterToggle by remember { mutableStateOf(false) }
+    var specifiedSemester: Pair<Int, SemesterType> by remember { mutableStateOf(2025 to SemesterType.One) }
     SoomsilUSaintTheme {
         SettingScreen(
-            settingUiState = SettingUiState.UserEditableSettings(notiToggle),
+            settingUiState = SettingUiState.UserEditableSettings(
+                notiToggle,
+                currentSemesterToggle,
+                specifiedSemester
+            ),
             onNotificationToggleChange = { notiToggle = it },
+            onSpecifiedCurrentSemester = { year, semester ->
+                currentSemesterToggle = true
+                specifiedSemester = year to semester
+            },
+            onUnspecifiedCurrentSemester = { currentSemesterToggle = false }
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun DialogPreview() {
+    SoomsilUSaintTheme {
+        CurrentSemesterSettingDialog(
+            year = 2025,
+            semester = SemesterType.One,
+            onConfirmClick = { _, _ -> },
+            onDismissRequest = {},
         )
     }
 }

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/setting/SettingViewModel.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/setting/SettingViewModel.kt
@@ -2,10 +2,12 @@ package com.yourssu.soomsil.usaint.screen.setting
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.yourssu.soomsil.usaint.core.types.SemesterType
 import com.yourssu.soomsil.usaint.data.repository.ReportCardRepository
 import com.yourssu.soomsil.usaint.data.repository.StudentCredentialRepository
 import com.yourssu.soomsil.usaint.data.repository.StudentDataRepository
 import com.yourssu.soomsil.usaint.data.repository.UserDataRepository
+import com.yourssu.soomsil.usaint.domain.usecase.GetCurrentSemesterUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -20,6 +22,7 @@ class SettingViewModel @Inject constructor(
     private val studentCredentialRepository: StudentCredentialRepository,
     private val studentDataRepository: StudentDataRepository,
     private val userDataRepository: UserDataRepository,
+    private val getCurrentSemesterUseCase: GetCurrentSemesterUseCase,
 //    private val updateWorkerUseCase: UpdateWorkerUseCase,
 ) : ViewModel() {
     val uiState: StateFlow<SettingUiState> =
@@ -27,6 +30,12 @@ class SettingViewModel @Inject constructor(
             .map {
                 SettingUiState.UserEditableSettings(
                     notificationEnabled = it.notificationEnabled,
+                    currentSemesterSpecified = it.isCurrentSemesterSpecified,
+                    specifiedCurrentSemester = if (it.isCurrentSemesterSpecified) {
+                        it.specifiedCurrentSemester
+                    } else {
+                        getCurrentSemesterUseCase.default()
+                    },
                 )
             }.stateIn(
                 scope = viewModelScope,
@@ -55,6 +64,18 @@ class SettingViewModel @Inject constructor(
             // TODO dequeue workmanager
         }
     }
+
+    fun specifyCurrentSemester(year: Int, semester: SemesterType) {
+        viewModelScope.launch {
+            userDataRepository.setCurrentSemesterSpecified(year, semester)
+        }
+    }
+
+    fun unspecifiedCurrentSemester() {
+        viewModelScope.launch {
+            userDataRepository.setCurrentSemesterUnspecified()
+        }
+    }
 }
 
 sealed interface SettingUiState {
@@ -62,5 +83,7 @@ sealed interface SettingUiState {
 
     data class UserEditableSettings(
         val notificationEnabled: Boolean,
+        val currentSemesterSpecified: Boolean,
+        val specifiedCurrentSemester: Pair<Int, SemesterType>?,
     ) : SettingUiState
 }

--- a/app/src/main/proto/user_preferences.proto
+++ b/app/src/main/proto/user_preferences.proto
@@ -6,4 +6,12 @@ option java_multiple_files = true;
 message UserPreferences {
   bool notificationEnabled = 1;
   bool includeSeasonalSemester = 2;
+
+  // 사용자가 현재 학기를 따로 설정했는지 여부를 나타냅니다.
+  // 설정 여부에 따라 [GetCurrentSemesterUseCase]의 반환값이 달라집니다.
+  // 설정했을 경우 `specifiedCurrentYear`와 `specifiedCurrentSemester`를 반환하며
+  // 설정하지 않았다면 기본 반환값이 반환됩니다.
+  bool isCurrentSemesterSpecified = 3;
+  int32 specifiedCurrentYear = 4;
+  string specifiedCurrentSemester = 5;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

X
https://yourssu.slack.com/archives/CPD6BSC92/p1746866260085089

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

![image](https://github.com/user-attachments/assets/ea410dca-88f0-487c-8115-60c4c84e6fc5)

![image](https://github.com/user-attachments/assets/75c3a8a9-fb94-4f45-880f-8b5c757924b4)

![image](https://github.com/user-attachments/assets/13306a3c-3e42-4558-a695-c08f5b69edba)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

GetCurrentSemesterUseCase에서 invoke 메서드 사용하면 알아서 현재 학기 불러옵니다