### PR TITLE
[fix] 학기별 상세 성적 Pager의 정렬이 가운데로 되던 문제 해결

### DIFF
--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/reportcard/ReportCardScreen.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/reportcard/ReportCardScreen.kt
@@ -153,11 +153,11 @@ private fun ChartSummary(
     reportCardUiState: ReportCardUiState,
     modifier: Modifier = Modifier,
 ) {
-    Column(modifier) {
-        when (reportCardUiState) {
-            is ReportCardUiState.Loading -> Unit
+    when (reportCardUiState) {
+        is ReportCardUiState.Loading -> Unit
 
-            is ReportCardUiState.ReportCard -> {
+        is ReportCardUiState.ReportCard -> {
+            Column(modifier) {
                 val semesters = reportCardUiState.semesterWithLectures.keys.toList()
                     .sortedWith(compareBy({ it.year }, { it.semester }))
                 val summary = reportCardUiState.summary
@@ -225,7 +225,10 @@ private fun SemesterTabsAndDetail(
                     }
                 }
 
-                HorizontalPager(state = pagerState) { pagerIndex ->
+                HorizontalPager(
+                    state = pagerState,
+                    verticalAlignment = Alignment.Top,
+                ) { pagerIndex ->
                     val semester = semesters.getOrNull(pagerIndex) ?: return@HorizontalPager
 
                     semesterWithLecturesMap[semester]?.let { lectureDataList ->


### PR DESCRIPTION
## #️⃣연관된 이슈
X

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

#### AS IS
문제상황:

https://github.com/user-attachments/assets/8078780b-688a-4984-a2df-b1979dd97a46

- HorizontalPager의 verticalAlignment의 기본값이 CenterVertically라서 발생한 문제였습니다.

```kt
// HorizontalPager 정의
@Composable
fun HorizontalPager(
    state: PagerState,
    modifier: Modifier = Modifier,
    /* ... */
    verticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
    /* ... */
    pageContent: @Composable PagerScope.(page: Int) -> Unit
)
```

- verticalAlignment를 Top으로 지정해주어 해결하였습니다.

```kt
                HorizontalPager(
                    state = pagerState,
                    verticalAlignment = Alignment.Top,
                ) { pagerIndex ->
```


#### TO BE
https://github.com/user-attachments/assets/41c3524b-4aed-488e-94f7-fa1f8eb90c11

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

Thanks to @Gael-Android 


