### PR TITLE
[feat] UI Scaffold 중복 제거 및 로딩 애니메이션 중복 제거

### DIFF
--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/MainActivity.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/MainActivity.kt
@@ -5,10 +5,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
-import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.yourssu.soomsil.usaint.screen.home.navigation.Home
 import com.yourssu.soomsil.usaint.screen.login.navigation.Login
@@ -33,9 +30,6 @@ class MainActivity : ComponentActivity() {
                     val credentialExist = mainUiState is MainUiState.Success
                     USaintApp(
                         startDestination = if (credentialExist) Home else Login,
-                        modifier = Modifier
-                            .navigationBarsPadding()
-                            .statusBarsPadding()
                     )
                 }
             }

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/navigation/TopLevelDestination.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/navigation/TopLevelDestination.kt
@@ -20,18 +20,21 @@ enum class TopLevelDestination(
     val unselectedIcon: ImageVector,
     val label: String,
     val route: KClass<*>,
+    val title: String,
 ) {
     HOME(
         selectedIcon = Icons.Filled.Home,
         unselectedIcon = Icons.Outlined.Home,
         label = "홈",
         route = Home::class,
+        title = "유세인트",
     ),
     REPORT_CARD(
         selectedIcon = Icons.Filled.School,
         unselectedIcon = Icons.Outlined.School,
         label = "성적",
         route = ReportCard::class,
+        title = "성적",
     ),
 //    CHAPEL(
 //        selectedIcon = Icons.Filled.Church,

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/navigation/USaintNavHost.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/navigation/USaintNavHost.kt
@@ -79,7 +79,11 @@ fun USaintNavHost(
                 snackbarHostState.showSnackbar(text)
             }
         )
-        reportCardScreen()
+        reportCardScreen(
+            reportCardSnackbarMessage = { text ->
+                snackbarHostState.showSnackbar(text)
+            }
+        )
 //        chapelScreen()
     }
 }

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/navigation/USaintNavHost.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/navigation/USaintNavHost.kt
@@ -15,6 +15,7 @@ import com.yourssu.soomsil.usaint.screen.login.navigation.navigateToLogin
 import com.yourssu.soomsil.usaint.screen.reportcard.navigation.reportCardScreen
 import com.yourssu.soomsil.usaint.screen.setting.navigation.navigateToSetting
 import com.yourssu.soomsil.usaint.screen.setting.navigation.settingScreen
+import androidx.core.net.toUri
 
 @Composable
 fun USaintNavHost(
@@ -50,7 +51,7 @@ fun USaintNavHost(
             },
             navigateToWebView = { url ->
                 CustomTabsIntent.Builder().build().also {
-                    it.launchUrl(context, Uri.parse(url))
+                    it.launchUrl(context, url.toUri())
                 }
             },
             navigateToLogin = {

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/HomeScreen.kt
@@ -3,7 +3,6 @@ package com.yourssu.soomsil.usaint.screen.home
 import android.content.Intent
 import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -20,9 +19,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -79,103 +76,93 @@ private fun HomeScreen(
     // 임시
     val context = LocalContext.current
 
-    val isHomeLoading = homeUiState is HomeUiState.Loading
+    val gisHomeLoading = homeUiState is HomeUiState.Loading
 
-    Scaffold(
-        modifier = modifier,
-        topBar = {
-            Box {
-                TopAppBar(title = { Text(text = "유세인트") })
-                AnimatedVisibility(
-                    visible = isFetching || isHomeLoading,
-                    modifier = Modifier.align(Alignment.BottomCenter),
-                ) {
-                    LinearProgressIndicator(Modifier.fillMaxWidth())
-                }
-            }
-        }
-    ) { padding ->
-        PullToRefreshBox(
-            isRefreshing = isRefreshing,
-            onRefresh = onRefresh,
-            Modifier
-                .padding(padding)
-                .fillMaxSize()
+    PullToRefreshBox(
+        isRefreshing = isRefreshing,
+        onRefresh = onRefresh,
+        modifier = modifier
+            .fillMaxSize()
+    ) {
+        AnimatedVisibility(
+            visible = isFetching,
+            modifier = Modifier.align(Alignment.TopCenter),
         ) {
-            Column(
-                modifier = Modifier
-                    .verticalScroll(rememberScrollState())
-                    .padding(
-                        horizontal = 16.dp,
-                        vertical = 12.dp,
-                    ),
-            ) {
-                val studentData =
-                    if (homeUiState is HomeUiState.Home) homeUiState.studentData else null
-                val reportCardSummaryData =
-                    if (homeUiState is HomeUiState.Home) homeUiState.reportCardSummaryData else null
+            LinearProgressIndicator(Modifier.fillMaxWidth())
+        }
+        Column(
+            modifier = Modifier
+                .verticalScroll(rememberScrollState())
+                .padding(
+                    horizontal = 16.dp,
+                    vertical = 12.dp,
+                ),
+        ) {
+            val studentData =
+                if (homeUiState is HomeUiState.Home) homeUiState.studentData else null
+            val reportCardSummaryData =
+                if (homeUiState is HomeUiState.Home) homeUiState.reportCardSummaryData else null
 
-                StudentDataItem(
-                    studentData = studentData,
-                    onProfileClick = onProfileClick,
-                    onSettingClick = onSettingClick,
-                )
+            StudentDataItem(
+                studentData = studentData,
+                onProfileClick = onProfileClick,
+                onSettingClick = onSettingClick,
+            )
 
-                Spacer(Modifier.height(8.dp))
-                ElevatedCard(
-                    onClick = {
-                        val intent = Intent(
-                            Intent.ACTION_VIEW,
-                            "https://trendwave-one.vercel.app/".toUri()
-                        )
-                        context.startActivity(intent)
-                    }
-                ) {
-                    Row(
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 16.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text(
-                            "\"TREND WAVE 2025\" 티켓 받으러 가기",
-                            modifier = Modifier
-                                .weight(1f)
-                                .padding(vertical = 16.dp)
-                        )
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Outlined.KeyboardArrowRight,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onSurface,
-                        )
-                    }
+            Spacer(Modifier.height(8.dp))
+            ElevatedCard(
+                onClick = {
+                    val intent = Intent(
+                        Intent.ACTION_VIEW,
+                        "https://trendwave-one.vercel.app/".toUri()
+                    )
+                    context.startActivity(intent)
                 }
-
-                Spacer(Modifier.height(8.dp))
-                Text(
-                    text = "내 성적",
-                    modifier = Modifier.padding(vertical = 4.dp),
-                    style = MaterialTheme.typography.titleLarge,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onSurface,
-                )
-
-                if (studentData?.status == "재학") {
-                    Spacer(Modifier.height(8.dp))
-                    ActionTitleItem(
-                        title = "이번 학기 성적 확인",
-                        onClick = {
-                            Toast.makeText(context, "서비스 예정입니다.", Toast.LENGTH_SHORT).show()
-                        },
+            ) {
+                Row(
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        "\"TREND WAVE 2025\" 티켓 받으러 가기",
+                        modifier = Modifier
+                            .weight(1f)
+                            .padding(vertical = 16.dp)
+                    )
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Outlined.KeyboardArrowRight,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurface,
                     )
                 }
+            }
 
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = "내 성적",
+                modifier = Modifier.padding(vertical = 4.dp),
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+
+            if (studentData?.status == "재학") {
                 Spacer(Modifier.height(8.dp))
-                ReportCardItem(
-                    reportCardSummary = reportCardSummaryData,
-                    onReportCardClick = onReportCardClick,
+                ActionTitleItem(
+                    title = "이번 학기 성적 확인",
+                    onClick = {
+                        Toast.makeText(context, "서비스 예정입니다.", Toast.LENGTH_SHORT).show()
+                    },
                 )
             }
+
+            Spacer(Modifier.height(8.dp))
+            ReportCardItem(
+                reportCardSummary = reportCardSummaryData,
+                onReportCardClick = onReportCardClick,
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/HomeScreen.kt
@@ -50,7 +50,6 @@ fun HomeScreen(
     val homeUiState by viewModel.homeUiState.collectAsStateWithLifecycle()
 
     HomeScreen(
-        isFetching = viewModel.isFetching,
         isRefreshing = viewModel.isRefreshing,
         onRefresh = { viewModel.fetchData(refresh = true) },
         homeUiState = homeUiState,
@@ -64,7 +63,6 @@ fun HomeScreen(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun HomeScreen(
-    isFetching: Boolean,
     isRefreshing: Boolean,
     onRefresh: () -> Unit,
     homeUiState: HomeUiState,
@@ -76,7 +74,7 @@ private fun HomeScreen(
     // 임시
     val context = LocalContext.current
 
-    val gisHomeLoading = homeUiState is HomeUiState.Loading
+    val isHomeLoading = homeUiState is HomeUiState.Loading
 
     PullToRefreshBox(
         isRefreshing = isRefreshing,
@@ -85,7 +83,7 @@ private fun HomeScreen(
             .fillMaxSize()
     ) {
         AnimatedVisibility(
-            visible = isFetching,
+            visible = isHomeLoading,
             modifier = Modifier.align(Alignment.TopCenter),
         ) {
             LinearProgressIndicator(Modifier.fillMaxWidth())
@@ -173,7 +171,6 @@ private fun HomePreview_being() {
     // 재학 상태
     SoomsilUSaintTheme {
         HomeScreen(
-            isFetching = false,
             isRefreshing = false,
             onRefresh = {},
             homeUiState = HomeUiState.Home(
@@ -190,7 +187,6 @@ private fun HomePreview_leave() {
     // 휴학 상태
     SoomsilUSaintTheme {
         HomeScreen(
-            isFetching = false,
             isRefreshing = false,
             onRefresh = {},
             homeUiState = HomeUiState.Home(

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/HomeScreen.kt
@@ -50,6 +50,7 @@ fun HomeScreen(
     val homeUiState by viewModel.homeUiState.collectAsStateWithLifecycle()
 
     HomeScreen(
+        hasInitialized = viewModel.hasInitialized,
         isRefreshing = viewModel.isRefreshing,
         onRefresh = { viewModel.fetchData(refresh = true) },
         homeUiState = homeUiState,
@@ -63,6 +64,7 @@ fun HomeScreen(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun HomeScreen(
+    hasInitialized: Boolean,
     isRefreshing: Boolean,
     onRefresh: () -> Unit,
     homeUiState: HomeUiState,
@@ -83,7 +85,7 @@ private fun HomeScreen(
             .fillMaxSize()
     ) {
         AnimatedVisibility(
-            visible = isHomeLoading,
+            visible = !hasInitialized,
             modifier = Modifier.align(Alignment.TopCenter),
         ) {
             LinearProgressIndicator(Modifier.fillMaxWidth())
@@ -171,6 +173,7 @@ private fun HomePreview_being() {
     // 재학 상태
     SoomsilUSaintTheme {
         HomeScreen(
+            hasInitialized = false,
             isRefreshing = false,
             onRefresh = {},
             homeUiState = HomeUiState.Home(
@@ -187,6 +190,7 @@ private fun HomePreview_leave() {
     // 휴학 상태
     SoomsilUSaintTheme {
         HomeScreen(
+            hasInitialized = false,
             isRefreshing = false,
             onRefresh = {},
             homeUiState = HomeUiState.Home(

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/HomeViewModel.kt
@@ -44,9 +44,6 @@ class HomeViewModel @Inject constructor(
                 initialValue = HomeUiState.Loading,
             )
 
-    var isFetching by mutableStateOf(false)
-        private set
-
     // 사용자가 직접 pull to refresh를 했을 경우에만 true
     var isRefreshing by mutableStateOf(false)
         private set
@@ -56,13 +53,11 @@ class HomeViewModel @Inject constructor(
     }
 
     fun fetchData(refresh: Boolean) {
-        if (isFetching || isRefreshing) return
+        if (isRefreshing) return
         viewModelScope.launch {
-            isFetching = true
             isRefreshing = refresh
             studentDataRepository.fetchStudentData().onFailure { e -> Timber.e(e) }
             reportCardRepository.fetchReportCardSummary().onFailure { e -> Timber.e(e) }
-            isFetching = false
             isRefreshing = false
         }
     }

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/HomeViewModel.kt
@@ -48,17 +48,21 @@ class HomeViewModel @Inject constructor(
     var isRefreshing by mutableStateOf(false)
         private set
 
+    var hasInitialized by mutableStateOf(false)
+        private set
+
     init {
         fetchData(refresh = false)
     }
 
     fun fetchData(refresh: Boolean) {
-        if (isRefreshing) return
+        if (isRefreshing || (!hasInitialized && refresh)) return
         viewModelScope.launch {
             isRefreshing = refresh
             studentDataRepository.fetchStudentData().onFailure { e -> Timber.e(e) }
             reportCardRepository.fetchReportCardSummary().onFailure { e -> Timber.e(e) }
             isRefreshing = false
+            hasInitialized = true
         }
     }
 }

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/reportcard/ReportCardScreen.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/reportcard/ReportCardScreen.kt
@@ -16,11 +16,9 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.LinearProgressIndicator
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SecondaryScrollableTabRow
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -73,41 +71,30 @@ private fun ReportCardScreen(
 ) {
     val isReportCardLoading = reportCardUiState is ReportCardUiState.Loading
 
-    Scaffold(
-        modifier = modifier,
-        topBar = {
-            Box {
-                TopAppBar(title = { Text(text = "성적") })
-                AnimatedVisibility(
-                    visible = isFetching || isReportCardLoading,
-                    modifier = Modifier.align(Alignment.BottomCenter),
-                ) {
-                    LinearProgressIndicator(Modifier.fillMaxWidth())
-                }
-            }
-        }
-    ) { padding ->
-        PullToRefreshBox(
-            isRefreshing = isRefreshing,
-            onRefresh = onRefresh,
-            Modifier
-                .fillMaxSize()
-                .padding(padding)
+    PullToRefreshBox(
+        isRefreshing = isRefreshing,
+        onRefresh = onRefresh,
+        modifier = modifier.fillMaxSize()
+    ) {
+        AnimatedVisibility(
+            visible = isFetching || isReportCardLoading,
+            modifier = Modifier.align(Alignment.TopCenter),
         ) {
-            Column(Modifier.verticalScroll(rememberScrollState())) {
-                if (isReportCardLoading) {
-                    Box(
-                        Modifier
-                            .fillMaxWidth()
-                            .weight(1f),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        CircularProgressIndicator()
-                    }
-                } else {
-                    ChartSummary(reportCardUiState)
-                    SemesterTabsAndDetail(reportCardUiState)
+            LinearProgressIndicator(Modifier.fillMaxWidth())
+        }
+        Column(Modifier.verticalScroll(rememberScrollState())) {
+            if (isReportCardLoading) {
+                Box(
+                    Modifier
+                        .fillMaxWidth()
+                        .weight(1f),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator()
                 }
+            } else {
+                ChartSummary(reportCardUiState)
+                SemesterTabsAndDetail(reportCardUiState)
             }
         }
     }

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/reportcard/ReportCardScreen.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/reportcard/ReportCardScreen.kt
@@ -32,7 +32,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.repeatOnLifecycle
 import com.yourssu.soomsil.usaint.core.model.LectureData
 import com.yourssu.soomsil.usaint.core.model.LectureGrade
 import com.yourssu.soomsil.usaint.core.model.Pass
@@ -48,9 +51,29 @@ import com.yourssu.soomsil.usaint.ui.theme.SoomsilUSaintTheme
 @Composable
 fun ReportCardScreen(
     modifier: Modifier = Modifier,
+    reportCardSnackbarMessage: suspend (String) -> Unit = {},
     viewModel: ReportCardViewModel = hiltViewModel(),
 ) {
+    val lifecycleOwner = LocalLifecycleOwner.current
     val reportCardUiState by viewModel.reportCardUiState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(lifecycleOwner.lifecycle) {
+        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            viewModel.reportCardEventFlow.collect { uiEvent ->
+                when (uiEvent) {
+                    ReportCardUiEvent.FetchStart ->
+                        reportCardSnackbarMessage("성적 정보를 불러오고 있습니다.")
+
+                    ReportCardUiEvent.FetchSuccess ->
+                        reportCardSnackbarMessage("성적 정보를 불러왔습니다.")
+
+                    is ReportCardUiEvent.FetchFailed ->
+                        reportCardSnackbarMessage(uiEvent.message?.let { "에러 발생: $it" }
+                            ?: "문제가 발생했습니다.")
+                }
+            }
+        }
+    }
 
     ReportCardScreen(
         hasInitialized = viewModel.hasInitialized,

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/reportcard/ReportCardScreen.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/reportcard/ReportCardScreen.kt
@@ -52,7 +52,7 @@ fun ReportCardScreen(
     val reportCardUiState by viewModel.reportCardUiState.collectAsStateWithLifecycle()
 
     ReportCardScreen(
-        isFetching = viewModel.isFetching,
+        hasInitialized = viewModel.hasInitialized,
         isRefreshing = viewModel.isRefreshing,
         onRefresh = { viewModel.fetchData(refresh = true) },
         reportCardUiState = reportCardUiState,
@@ -63,7 +63,7 @@ fun ReportCardScreen(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun ReportCardScreen(
-    isFetching: Boolean,
+    hasInitialized: Boolean,
     isRefreshing: Boolean,
     onRefresh: () -> Unit,
     reportCardUiState: ReportCardUiState,
@@ -77,7 +77,7 @@ private fun ReportCardScreen(
         modifier = modifier.fillMaxSize()
     ) {
         AnimatedVisibility(
-            visible = isFetching || isReportCardLoading,
+            visible = !hasInitialized,
             modifier = Modifier.align(Alignment.TopCenter),
         ) {
             LinearProgressIndicator(Modifier.fillMaxWidth())
@@ -240,7 +240,7 @@ private fun ReportCardScreenPreview() {
 
     SoomsilUSaintTheme {
         ReportCardScreen(
-            isFetching = false,
+            hasInitialized = false,
             isRefreshing = false,
             onRefresh = {},
             reportCardUiState = ReportCardUiState.ReportCard(
@@ -256,7 +256,7 @@ private fun ReportCardScreenPreview() {
 private fun ReportCardScreenPreview_loading() {
     SoomsilUSaintTheme {
         ReportCardScreen(
-            isFetching = false,
+            hasInitialized = false,
             isRefreshing = false,
             onRefresh = {},
             reportCardUiState = ReportCardUiState.Loading,

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/reportcard/ReportCardViewModel.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/reportcard/ReportCardViewModel.kt
@@ -42,11 +42,11 @@ class ReportCardViewModel @Inject constructor(
             initialValue = ReportCardUiState.Loading,
         )
 
-    var isFetching by mutableStateOf(false)
-        private set
-
     // 사용자가 직접 pull to refresh를 했을 경우에만 true
     var isRefreshing by mutableStateOf(false)
+        private set
+
+    var hasInitialized by mutableStateOf(false)
         private set
 
     init {
@@ -54,13 +54,12 @@ class ReportCardViewModel @Inject constructor(
     }
 
     fun fetchData(refresh: Boolean) {
-        if (isFetching || isRefreshing) return
+        if (isRefreshing || (!hasInitialized && refresh)) return
         viewModelScope.launch {
-            isFetching = true
             isRefreshing = refresh
             // TODO 에러처리
             reportCardRepository.fetchSemesterWithLectures().onFailure { e -> Timber.e(e) }
-            isFetching = false
+            hasInitialized = true
             isRefreshing = false
         }
     }

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/reportcard/navigation/ReportCardNavigation.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/reportcard/navigation/ReportCardNavigation.kt
@@ -13,8 +13,12 @@ data object ReportCard
 fun NavHostController.navigateToReportCard(navOptions: NavOptions? = null) =
     navigate(ReportCard, navOptions)
 
-fun NavGraphBuilder.reportCardScreen() {
+fun NavGraphBuilder.reportCardScreen(
+    reportCardSnackbarMessage: suspend (String) -> Unit,
+) {
     composable<ReportCard> {
-        ReportCardScreen()
+        ReportCardScreen(
+            reportCardSnackbarMessage = reportCardSnackbarMessage
+        )
     }
 }

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/ui/USaintApp.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/ui/USaintApp.kt
@@ -1,5 +1,6 @@
 package com.yourssu.soomsil.usaint.ui
 
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
@@ -58,7 +59,9 @@ fun USaintApp(
         USaintNavHost(
             navController = navController,
             startDestination = startDestination,
-            modifier = Modifier.padding(padding),
+            modifier = Modifier
+                .padding(padding)
+                .consumeWindowInsets(padding),
         )
     }
 }

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/ui/USaintApp.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/ui/USaintApp.kt
@@ -1,13 +1,9 @@
 package com.yourssu.soomsil.usaint.ui
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.consumeWindowInsets
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
@@ -16,7 +12,6 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavDestination
 import androidx.navigation.NavDestination.Companion.hasRoute

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/ui/USaintApp.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/ui/USaintApp.kt
@@ -1,15 +1,22 @@
 package com.yourssu.soomsil.usaint.ui
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavDestination
 import androidx.navigation.NavDestination.Companion.hasRoute
@@ -20,6 +27,7 @@ import com.yourssu.soomsil.usaint.navigation.USaintNavHost
 import com.yourssu.soomsil.usaint.navigation.navigateToTopLevelDestination
 import kotlin.reflect.KClass
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun USaintApp(
     startDestination: Any,
@@ -35,6 +43,11 @@ fun USaintApp(
 
     Scaffold(
         modifier = modifier,
+        topBar = {
+            currentTopLevelDestination?.let {
+                TopAppBar(title = { Text(text = it.title) })
+            }
+        },
         bottomBar = {
             if (currentTopLevelDestination != null) {
                 NavigationBar {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

+ `Scaffold`가 중첩되어 `padding`이 중복으로 일어나 UI가 밀리는 걸 각 Screen에서의 Scaffold를 제거해서 해결했습니다.
+ `LinearProgressIndicator`랑 `PullToRefreshBox`의 로딩 애니메이션이 동시에 나오는 걸 `LinearProgressIndicator`는 초기 `Loading`에서는 하도록 변경했습니다.
+ 막상 보니까 조금 어색해서 다시 수정하고 draft 풀게용

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
