### PR TITLE
현재학기 판단 기준 수정

### DIFF
--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/domain/usecase/GetCurrentSemesterUseCase.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/domain/usecase/GetCurrentSemesterUseCase.kt
@@ -21,25 +21,25 @@ class GetCurrentSemesterUseCase @Inject constructor(
 
         // 2025년도 학기 개강 ~ 종강
         // https://ssu.ac.kr/%ED%95%99%EC%82%AC/%ED%95%99%EC%82%AC%EC%9D%BC%EC%A0%95/
-        // 1학기: 3/4 ~ 6/23
-        // 여름학기: 6/24 ~ 7/14
-        // 2학기: 9/1 ~ 12/20
-        // 겨울학기: 12/22 ~ 1/15
+        // 1학기: 3/4 ~ 6/23 (성적 처리기간 ~7.7)
+        // 여름학기: 6/24 ~ 7/14 (성적 처리기간 ~7.31)
+        // 2학기: 9/1 ~ 12/20 (성적 처리기간 ~1.7)
+        // 겨울학기: 12/22 ~ 1/15 (성적 처리기간 ~1.31)
         return when (now) {
-            in LocalDate.of(year, 3, 4)..LocalDate.of(year, 6, 23) ->
+            in LocalDate.of(year, 3, 4)..LocalDate.of(year, 7, 7) ->
                 Pair(year, SemesterType.One)
 
-            in LocalDate.of(year, 6, 24)..LocalDate.of(year, 7, 14) ->
+            in LocalDate.of(year, 7, 8)..LocalDate.of(year, 7, 14) ->
                 Pair(year, SemesterType.Summer)
 
-            in LocalDate.of(year, 9, 1)..LocalDate.of(year, 12, 20) ->
+            in LocalDate.of(year, 9, 1)..LocalDate.of(year, 12, 31) ->
                 Pair(year, SemesterType.Two)
 
-            in LocalDate.of(year, 12, 22)..LocalDate.of(year, 12, 31) ->
-                Pair(year, SemesterType.Winter)
+            in LocalDate.of(year, 1, 1)..LocalDate.of(year, 1, 7) ->
+                Pair(year-1, SemesterType.Two)
 
-            in LocalDate.of(year, 1, 1)..LocalDate.of(year, 1, 15) ->
-                Pair(year - 1, SemesterType.Winter)
+            in LocalDate.of(year, 1, 8)..LocalDate.of(year, 1, 31) ->
+                Pair(year-1, SemesterType.Winter)
 
             else -> null
         }


### PR DESCRIPTION
## #️⃣연관된 이슈

#92  

## 📝작업 내용

정규학기 시작은 그대로 두고 종료일자를 약 2주씩 늦췄습니다.


## 💬리뷰 요구사항(선택)

기억이 잘 안나는데 채플도 학기 시작하자마자 자리랑 주차별 예정사항이 떴나요? 
안뜨면 HomeScreen에서 좌석은 빈칸으로 보이고 채플탭도 출결 현황은 휑할거라 따로 문구를 띄우거나 학기 시작을 늦춰야할거 같아요