### PR TITLE
지난 학기와 같은 시간대의 채플을 듣는 경우 데이터가 병합되던 문제 해결

### DIFF
--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/repository/ChapelRepository.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/repository/ChapelRepository.kt
@@ -1,6 +1,5 @@
 package com.yourssu.soomsil.usaint.data.repository
 
-import com.yourssu.soomsil.usaint.core.model.ChapelAttendanceData
 import com.yourssu.soomsil.usaint.core.model.ChapelData
 import com.yourssu.soomsil.usaint.core.model.SemesterData
 import com.yourssu.soomsil.usaint.core.types.SemesterType
@@ -42,7 +41,16 @@ class ChapelRepository @Inject constructor(
     val chapelCard: Flow<ChapelData?> = // 현재 학기 설정에 따른 카드에 표시할 채플정보
             chapels.map { chapelList ->
                 chapelList.find {
-                    it.chapelSimpleData.division == chapelDataSource.chapelCardData.first().division
+                    val savedCardData = chapelDataSource.chapelCardData.first()
+
+                    it.chapelSimpleData.division == savedCardData.division
+                            // 채플 주차별 정보에서 첫 수업일자를 가져와서 설정한 현재연도와 일치하는지 확인
+                            // 해당학기 채플 주차별 데이터가 불러와지기 전 chapelCard를 호출하는 경우 ArrayIndexOutOfBoundsException
+                            && (it.chapelAttendances.any() && it.chapelAttendances[0].classDate.startsWith(savedCardData.year.toString()))
+                            // 수업 월이 7월 이전이면 1학기 채플인지 확인하고 8월 이후면 2학기 채플인것을 확인하고 현재 채플 정보로 반영
+                            // (같은 학년도에 같은 분반으로 1,2학기 수업을 들을 경우 여기서 걸러져야 함)
+                            && ((it.chapelAttendances[0].classDate.substring(5, 7).toInt() <= 7 && savedCardData.semester == SemesterType.One)
+                                || (it.chapelAttendances[0].classDate.substring(5, 7).toInt() > 7 && savedCardData.semester == SemesterType.Two))
                 }
             }
 
@@ -53,11 +61,19 @@ class ChapelRepository @Inject constructor(
         val chapelCardData = uSaintRemoteSource.remoteChapelData(
             credential,
             specifiedCurrentSemester.first,
-            specifiedCurrentSemester.second)
+            specifiedCurrentSemester.second
+        )
+
+        // TODO 기존 채플 과목코드에 대해 지우는 코드입니다. 나중에 삭제해주세요
+        chapelDao.deleteChapelAttendancesEntitiesWithDivision(chapelCardData.chapelSimpleData.division)
+        chapelDao.deleteChapelEntityWithDivision(chapelCardData.chapelSimpleData.division)
+        // ---
 
         chapelDataSource.setChapelCardData(chapelSimpleData = chapelCardData.chapelSimpleData)
         chapelDao.upsertChapel(chapelCardData.chapelSimpleData.asEntity())
-        chapelDao.upsertChapelAttendances(chapelCardData.chapelAttendances.map(ChapelAttendanceData::asEntity))
+        chapelDao.upsertChapelAttendances(chapelCardData.chapelAttendances.map {
+            it.asEntity(specifiedCurrentSemester.first, specifiedCurrentSemester.second)
+        })
     }
 
     // 현재 학기를 제외한 이수한 학기의 채플 정보를 모두 불러옵니다.
@@ -74,8 +90,15 @@ class ChapelRepository @Inject constructor(
                     semesterData.semester
                 )
 
+                // TODO 기존 채플 과목코드에 대해 지우는 코드입니다. 나중에 삭제해주세요
+                chapelDao.deleteChapelAttendancesEntitiesWithDivision(chapelData.chapelSimpleData.division)
+                chapelDao.deleteChapelEntityWithDivision(chapelData.chapelSimpleData.division)
+                // ---
+
                 chapelDao.upsertChapel(chapelData.chapelSimpleData.asEntity())
-                chapelDao.upsertChapelAttendances(chapelData.chapelAttendances.map(ChapelAttendanceData::asEntity))
+                chapelDao.upsertChapelAttendances(chapelData.chapelAttendances.map {
+                    it.asEntity(semesterData.year, semesterData.semester)
+                })
             } catch (e: Exception) {
                 // 계절학기, 6회 수강 완료 등 채플 데이터가 없는 학기에 대해서는
                 // 에러가 발생하지만 동작이 멈추면 안되고 다음 학기를 검색해야함

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/source/local/dao/ChapelDao.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/source/local/dao/ChapelDao.kt
@@ -36,8 +36,17 @@ interface ChapelDao {
     @Query("DELETE FROM Chapel WHERE year = :year AND semester = :semesterName")
     suspend fun deleteChapelEntitiesWithYearSemester(year: Int, semesterName: String)
 
+    /**
+     * @param division (division * 100000) + (year * 10) + semester.ordinal의 값으로 넣어주세요.
+     */
+    @Query("DELETE FROM Chapel WHERE division = :division")
+    suspend fun deleteChapelEntityWithDivision(division: Long)
+
+    /**
+     * @param division (division * 100000) + (year * 10) + semester.ordinal의 값으로 넣어주세요.
+     */
     @Query("DELETE FROM ChapelAttendance WHERE division = :division")
-    suspend fun deleteChapelAttendancesEntitiesWithDivision(division: Int)
+    suspend fun deleteChapelAttendancesEntitiesWithDivision(division: Long)
 
     @Query("DELETE FROM Chapel")
     suspend fun deleteAllChapel()

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/source/local/datastore/ChapelDataSource.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/source/local/datastore/ChapelDataSource.kt
@@ -17,7 +17,7 @@ class ChapelDataSource @Inject constructor (
         .map {
             ChapelSimpleData(
                 year = it.year,
-                semester = SemesterType.One,
+                semester = SemesterType.valueOf(it.semester),
                 division = it.division,
                 chapelRoom = it.chapelRoom,
                 chapelTime = it.chapelTime,

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/source/local/entity/ChapelAttendanceEntity.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/source/local/entity/ChapelAttendanceEntity.kt
@@ -5,6 +5,7 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import com.yourssu.soomsil.usaint.core.model.ChapelAttendanceData
+import com.yourssu.soomsil.usaint.core.types.SemesterType
 
 
 @Entity(
@@ -34,7 +35,7 @@ data class ChapelAttendanceEntity(
 )
 
 fun ChapelAttendanceEntity.asExternalModel() = ChapelAttendanceData(
-    division = division,
+    division = division / 100000,
     classDate = classDate,
     category = category,
     instructor = instructor,
@@ -45,8 +46,8 @@ fun ChapelAttendanceEntity.asExternalModel() = ChapelAttendanceData(
     note = note
 )
 
-fun ChapelAttendanceData.asEntity() = ChapelAttendanceEntity(
-    division = division,
+fun ChapelAttendanceData.asEntity(year: Int, semester: SemesterType) = ChapelAttendanceEntity(
+    division = (division * 100000) + (year * 10) + semester.ordinal,
     classDate = classDate,
     category = category,
     instructor = instructor,

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/source/local/entity/ChapelEntity.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/source/local/entity/ChapelEntity.kt
@@ -32,7 +32,7 @@ data class ChapelEntity(
 fun ChapelEntity.asExternalModel() = ChapelSimpleData(
     year = year,
     semester = enumValueOf<SemesterType>(semester),
-    division = division,
+    division = division / 100000,
     chapelTime = chapelTime,
     chapelRoom = chapelRoom,
     floorLevel = floorLevel,
@@ -45,7 +45,7 @@ fun ChapelEntity.asExternalModel() = ChapelSimpleData(
 fun ChapelSimpleData.asEntity() = ChapelEntity(
     year = year,
     semester = semester.name,
-    division = division,
+    division = (division * 100000) + (year * 10) + semester.ordinal,
     chapelTime = chapelTime,
     chapelRoom = chapelRoom,
     floorLevel = floorLevel,

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/components/ChapelCardItem.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/components/ChapelCardItem.kt
@@ -70,7 +70,7 @@ fun ChapelCardItem(
                                 SpanStyle(color = MaterialTheme.colorScheme.primary)
                             ) {
                                 append(
-                                    "${ceil(totalAttendance * (2 / 3.0)) - currentAttendance}회 "
+                                    "${ceil(totalAttendance * (2 / 3.0)).toInt() - currentAttendance}회 "
                                 )
                             }
                             append("남았어요.")

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/login/LoginViewModel.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/login/LoginViewModel.kt
@@ -55,6 +55,10 @@ class LoginViewModel @Inject constructor(
             // id/pw 저장
             studentCredentialRepository.setStudentCredential(credential)
             // 저장된 id/pw로 학생 데이터 가져오기 시도
+            getCurrentSemesterUseCase()?.let {
+                chapelRepository.fetchChapelCardData(it)
+                    .onFailure { e -> Timber.e(e) }
+            }
             studentDataRepository.fetchStudentData()
                 .onSuccess {
                     studentCredentialRepository.setLoggedIn(true)
@@ -64,11 +68,6 @@ class LoginViewModel @Inject constructor(
                 .onFailure { e ->
                     _uiEvent.emit(LoginUiEvent.Failure(e.message))
                 }
-
-            getCurrentSemesterUseCase()?.let {
-                chapelRepository.fetchChapelCardData(it)
-                    .onFailure { e -> Timber.e(e) }
-            }
 
             isLoading = false
         }


### PR DESCRIPTION
- DB 내 division에 연도와 학기 데이터를 함께 포함해서 저장
- 기존 채플 정보들을 로그아웃 없이 삭제하는 코드 포함

## 📝작업 내용
<img width="1600" height="384" alt="Android Studio 2025 09 09 230225@2x" src="https://github.com/user-attachments/assets/52017971-df77-4db9-a1b7-22af852d9e73" />
division 값 뒤에 연도와, 학기 정보(1학기는 0, 2학기는 2)로 5자리 더 붙였습니다  
<br>
DB 안에서만 이런식으로 저장되고 꺼내올때는 뒤에 5자리를 날려버리고 원래 과목코드로 가져옵니다
<br>
  
<img width="30%"  alt="image" src="https://github.com/user-attachments/assets/31ec62f4-75e2-4a28-9cd8-e64f51f3652a" />
<img width="30%"  alt="Android Studio 2025 09 09 233202@2x" src="https://github.com/user-attachments/assets/95b7a262-8b9f-4d11-8014-1676596ca535" />
<img width="30%"  alt="Android Studio 2025 09 09 233159@2x" src="https://github.com/user-attachments/assets/39526f2a-6d7d-4a3f-82f5-ff49ab5261c0" />

좌측 : 비포, 중앙 우측 : 애프터


## 💬리뷰 요구사항(선택)

> 기존 DB 구조 건드리기 싫어서 이렇게 했는데 너무 지저분한가요??
> 이 방법 말고 Chapel 테이블에서 division 열에 기본키를 유지하면서 해결할 다른 방법이 뭐가 있는지 모르겠어요..