### PR TITLE
지난 학기와 같은 시간대의 채플을 듣는 경우 데이터가 병합되던 문제 해결

### DIFF
--- a/app/schemas/com.yourssu.soomsil.usaint.data.source.local.AppDatabase/6.json
+++ b/app/schemas/com.yourssu.soomsil.usaint.data.source.local.AppDatabase/6.json
@@ -1,8 +1,8 @@
 {
   "formatVersion": 1,
   "database": {
-    "version": 5,
-    "identityHash": "ec6cbb7d308ae4f82cee1ed6a649324c",
+    "version": 6,
+    "identityHash": "c1bef6991fee1496cba58aab2fbf79b1",
     "entities": [
       {
         "tableName": "Semester",
@@ -176,7 +176,7 @@
       },
       {
         "tableName": "Chapel",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`year` INTEGER NOT NULL DEFAULT 0, `semester` TEXT NOT NULL DEFAULT 'One', `division` INTEGER NOT NULL DEFAULT 0, `chapelTime` TEXT NOT NULL, `chapelRoom` TEXT NOT NULL, `floorLevel` INTEGER NOT NULL, `seatNumber` TEXT NOT NULL, `absenceTime` INTEGER NOT NULL, `result` TEXT NOT NULL, PRIMARY KEY(`division`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`year` INTEGER NOT NULL DEFAULT 0, `semester` TEXT NOT NULL DEFAULT 'One', `division` INTEGER NOT NULL DEFAULT 0, `chapelTime` TEXT NOT NULL, `chapelRoom` TEXT NOT NULL, `floorLevel` INTEGER NOT NULL, `seatNumber` TEXT NOT NULL, `absenceTime` INTEGER NOT NULL, `result` TEXT NOT NULL, PRIMARY KEY(`year`, `semester`, `division`))",
         "fields": [
           {
             "fieldPath": "year",
@@ -239,24 +239,28 @@
         "primaryKey": {
           "autoGenerate": false,
           "columnNames": [
+            "year",
+            "semester",
             "division"
           ]
         },
         "indices": [
           {
-            "name": "index_Chapel_division",
+            "name": "index_Chapel_year_semester_division",
             "unique": true,
             "columnNames": [
+              "year",
+              "semester",
               "division"
             ],
             "orders": [],
-            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_Chapel_division` ON `${TABLE_NAME}` (`division`)"
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_Chapel_year_semester_division` ON `${TABLE_NAME}` (`year`, `semester`, `division`)"
           }
         ]
       },
       {
         "tableName": "ChapelAttendance",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`year` INTEGER NOT NULL DEFAULT 0, `semester` TEXT NOT NULL DEFAULT 'One', `division` INTEGER NOT NULL DEFAULT 0, `classDate` TEXT NOT NULL, `category` TEXT NOT NULL, `instructor` TEXT NOT NULL, `instructorDepartment` TEXT NOT NULL, `title` TEXT NOT NULL, `attendance` TEXT NOT NULL, `result` TEXT NOT NULL, `note` TEXT NOT NULL, PRIMARY KEY(`year`, `semester`, `classDate`), FOREIGN KEY(`division`) REFERENCES `Chapel`(`division`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`year` INTEGER NOT NULL DEFAULT 0, `semester` TEXT NOT NULL DEFAULT 'One', `division` INTEGER NOT NULL DEFAULT 0, `classDate` TEXT NOT NULL, `category` TEXT NOT NULL, `instructor` TEXT NOT NULL, `instructorDepartment` TEXT NOT NULL, `title` TEXT NOT NULL, `attendance` TEXT NOT NULL, `result` TEXT NOT NULL, `note` TEXT NOT NULL, PRIMARY KEY(`year`, `semester`, `classDate`), FOREIGN KEY(`year`, `semester`, `division`) REFERENCES `Chapel`(`year`, `semester`, `division`) ON UPDATE NO ACTION ON DELETE CASCADE )",
         "fields": [
           {
             "fieldPath": "year",
@@ -355,9 +359,13 @@
             "onDelete": "CASCADE",
             "onUpdate": "NO ACTION",
             "columns": [
+              "year",
+              "semester",
               "division"
             ],
             "referencedColumns": [
+              "year",
+              "semester",
               "division"
             ]
           }
@@ -366,7 +374,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'ec6cbb7d308ae4f82cee1ed6a649324c')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'c1bef6991fee1496cba58aab2fbf79b1')"
     ]
   }
 }

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/core/model/ChapelAttendanceData.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/core/model/ChapelAttendanceData.kt
@@ -1,6 +1,10 @@
 package com.yourssu.soomsil.usaint.core.model
 
+import com.yourssu.soomsil.usaint.core.types.SemesterType
+
 data class ChapelAttendanceData(
+    val year: Int,
+    val semester: SemesterType,
     val division: Long,
     val classDate: String,
     val category: String,
@@ -13,6 +17,8 @@ data class ChapelAttendanceData(
 ) {
     companion object {
         val previewData = ChapelAttendanceData(
+            year = 2025,
+            semester = SemesterType.One,
             division = 100012345,
             classDate = "2024-3-29",
             category = "메세지 채플",

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/repository/ChapelRepository.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/repository/ChapelRepository.kt
@@ -13,6 +13,7 @@ import com.yourssu.soomsil.usaint.data.source.local.entity.asEntity
 import com.yourssu.soomsil.usaint.data.source.local.entity.asExternalModel
 import com.yourssu.soomsil.usaint.data.source.remote.USaintRemoteSource
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
@@ -27,14 +28,21 @@ class ChapelRepository @Inject constructor(
 
     // 채플DB에서 지금까지 불러왔던 모든 채플 데이터(현재학기 + 이전학기)를 불러옵니다.
     val chapels: Flow<List<ChapelData>> = // 전체 채플 정보
-        chapelDao.getChapels().map { chapelList ->
-            chapelList
-                .map {
-                    ChapelData(
-                        it.chapel.asExternalModel(),
-                        it.attendances.map(ChapelAttendanceEntity::asExternalModel)
-                    )
-                }
+        combine(
+            chapelDao.getAllChapels(),
+            chapelDao.getAllAttendances()
+        ) { chapels, attendances ->
+            val attendancesMap = attendances.groupBy {
+                Triple(it.year, it.semester, it.division)
+            }
+
+            chapels.map { chapel ->
+                val compositeKey = Triple(chapel.year, chapel.semester, chapel.division)
+                ChapelData(
+                    chapelSimpleData = chapel.asExternalModel(),
+                    chapelAttendances = attendancesMap[compositeKey]?.map(ChapelAttendanceEntity::asExternalModel) ?: emptyList()
+                )
+            }
         }
 
     // getCurrentSemesterUseCase를 사용하기가 어려워서

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/repository/ChapelRepository.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/repository/ChapelRepository.kt
@@ -14,8 +14,6 @@ import com.yourssu.soomsil.usaint.data.source.local.entity.asExternalModel
 import com.yourssu.soomsil.usaint.data.source.remote.USaintRemoteSource
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 class ChapelRepository @Inject constructor(
@@ -40,35 +38,41 @@ class ChapelRepository @Inject constructor(
                 val compositeKey = Triple(chapel.year, chapel.semester, chapel.division)
                 ChapelData(
                     chapelSimpleData = chapel.asExternalModel(),
-                    chapelAttendances = attendancesMap[compositeKey]?.map(ChapelAttendanceEntity::asExternalModel) ?: emptyList()
+                    chapelAttendances = attendancesMap[compositeKey]?.map(ChapelAttendanceEntity::asExternalModel)
+                        ?: emptyList()
                 )
             }
         }
 
     // getCurrentSemesterUseCase를 사용하기가 어려워서
     // 전체 채플 데이터에서 DataStore에 저장한 분반 정보를 비교하여 뽑아냅니다.
-    val chapelCard: Flow<ChapelData?> = // 현재 학기 설정에 따른 카드에 표시할 채플정보
-        chapels.map { chapelList ->
+    val chapelCard: Flow<ChapelData?> =
+        combine(chapels, chapelDataSource.chapelCardData) { chapelList, cardData ->
             chapelList.find {
-                it.chapelSimpleData.year == chapelDataSource.chapelCardData.first().year &&
-                        it.chapelSimpleData.semester == chapelDataSource.chapelCardData.first().semester
+                it.chapelSimpleData.year == cardData.year &&
+                        it.chapelSimpleData.semester == cardData.semester
             }
         }
 
     // 앱이 최초에 실행될 때 이 함수가 먼저 실행됩니다.
     // 채플 DB와 DataStore에 불러온 값을 저장합니다.
-    suspend fun fetchChapelCardData(specifiedCurrentSemester: Pair<Int, SemesterType>): Result<Unit> = runCatching {
-        val credential = studentCredential.getStudentCredential()
-        val chapelCardData = uSaintRemoteSource.remoteChapelData(
-            credential,
-            specifiedCurrentSemester.first,
-            specifiedCurrentSemester.second
-        )
+    suspend fun fetchChapelCardData(specifiedCurrentSemester: Pair<Int, SemesterType>): Result<Unit> =
+        runCatching {
+            val credential = studentCredential.getStudentCredential()
+            val chapelCardData = uSaintRemoteSource.remoteChapelData(
+                credential,
+                specifiedCurrentSemester.first,
+                specifiedCurrentSemester.second
+            )
 
-        chapelDataSource.setChapelCardData(chapelSimpleData = chapelCardData.chapelSimpleData)
-        chapelDao.upsertChapel(chapelCardData.chapelSimpleData.asEntity())
-        chapelDao.upsertChapelAttendances(chapelCardData.chapelAttendances.map(ChapelAttendanceData::asEntity))
-    }
+            chapelDataSource.setChapelCardData(chapelSimpleData = chapelCardData.chapelSimpleData)
+            chapelDao.upsertChapel(chapelCardData.chapelSimpleData.asEntity())
+            chapelDao.upsertChapelAttendances(
+                chapelCardData.chapelAttendances.map(
+                    ChapelAttendanceData::asEntity
+                )
+            )
+        }
 
     // 현재 학기를 제외한 이수한 학기의 채플 정보를 모두 불러옵니다.
     // 채플 DB에 불러온 값을 저장합니다.
@@ -85,8 +89,11 @@ class ChapelRepository @Inject constructor(
                 )
 
                 chapelDao.upsertChapel(chapelData.chapelSimpleData.asEntity())
-                chapelDao.upsertChapelAttendances(chapelData.chapelAttendances.map(
-                    ChapelAttendanceData::asEntity))
+                chapelDao.upsertChapelAttendances(
+                    chapelData.chapelAttendances.map(
+                        ChapelAttendanceData::asEntity
+                    )
+                )
             } catch (e: Exception) {
                 // 계절학기, 6회 수강 완료 등 채플 데이터가 없는 학기에 대해서는
                 // 에러가 발생하지만 동작이 멈추면 안되고 다음 학기를 검색해야함

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/repository/ChapelRepository.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/repository/ChapelRepository.kt
@@ -1,6 +1,5 @@
 package com.yourssu.soomsil.usaint.data.repository
 
-import com.yourssu.soomsil.usaint.core.model.ChapelAttendanceData
 import com.yourssu.soomsil.usaint.core.model.ChapelData
 import com.yourssu.soomsil.usaint.core.model.SemesterData
 import com.yourssu.soomsil.usaint.core.types.SemesterType
@@ -42,7 +41,16 @@ class ChapelRepository @Inject constructor(
     val chapelCard: Flow<ChapelData?> = // 현재 학기 설정에 따른 카드에 표시할 채플정보
             chapels.map { chapelList ->
                 chapelList.find {
-                    it.chapelSimpleData.division == chapelDataSource.chapelCardData.first().division
+                    val savedCardData = chapelDataSource.chapelCardData.first()
+
+                    it.chapelSimpleData.division == savedCardData.division
+                            // 채플 주차별 정보에서 첫 수업일자를 가져와서 설정한 현재연도와 일치하는지 확인
+                            // 해당학기 채플 주차별 데이터가 불러와지기 전 chapelCard를 호출하는 경우 ArrayIndexOutOfBoundsException
+                            && (it.chapelAttendances.any() && it.chapelAttendances[0].classDate.startsWith(savedCardData.year.toString()))
+                            // 수업 월이 7월 이전이면 1학기 채플인지 확인하고 8월 이후면 2학기 채플인것을 확인하고 현재 채플 정보로 반영
+                            // (같은 학년도에 같은 분반으로 1,2학기 수업을 들을 경우 여기서 걸러져야 함)
+                            && ((it.chapelAttendances[0].classDate.substring(5, 7).toInt() <= 7 && savedCardData.semester == SemesterType.One)
+                                || (it.chapelAttendances[0].classDate.substring(5, 7).toInt() > 7 && savedCardData.semester == SemesterType.Two))
                 }
             }
 
@@ -53,11 +61,19 @@ class ChapelRepository @Inject constructor(
         val chapelCardData = uSaintRemoteSource.remoteChapelData(
             credential,
             specifiedCurrentSemester.first,
-            specifiedCurrentSemester.second)
+            specifiedCurrentSemester.second
+        )
+
+        // TODO 기존 채플 과목코드에 대해 지우는 코드입니다. 나중에 삭제해주세요
+        chapelDao.deleteChapelAttendancesEntitiesWithDivision(chapelCardData.chapelSimpleData.division)
+        chapelDao.deleteChapelEntityWithDivision(chapelCardData.chapelSimpleData.division)
+        // ---
 
         chapelDataSource.setChapelCardData(chapelSimpleData = chapelCardData.chapelSimpleData)
         chapelDao.upsertChapel(chapelCardData.chapelSimpleData.asEntity())
-        chapelDao.upsertChapelAttendances(chapelCardData.chapelAttendances.map(ChapelAttendanceData::asEntity))
+        chapelDao.upsertChapelAttendances(chapelCardData.chapelAttendances.map {
+            it.asEntity(specifiedCurrentSemester.first, specifiedCurrentSemester.second)
+        })
     }
 
     // 현재 학기를 제외한 이수한 학기의 채플 정보를 모두 불러옵니다.
@@ -74,8 +90,15 @@ class ChapelRepository @Inject constructor(
                     semesterData.semester
                 )
 
+                // TODO 기존 채플 과목코드에 대해 지우는 코드입니다. 나중에 삭제해주세요
+                chapelDao.deleteChapelAttendancesEntitiesWithDivision(chapelData.chapelSimpleData.division)
+                chapelDao.deleteChapelEntityWithDivision(chapelData.chapelSimpleData.division)
+                // ---
+
                 chapelDao.upsertChapel(chapelData.chapelSimpleData.asEntity())
-                chapelDao.upsertChapelAttendances(chapelData.chapelAttendances.map(ChapelAttendanceData::asEntity))
+                chapelDao.upsertChapelAttendances(chapelData.chapelAttendances.map {
+                    it.asEntity(semesterData.year, semesterData.semester)
+                })
             } catch (e: Exception) {
                 // 계절학기, 6회 수강 완료 등 채플 데이터가 없는 학기에 대해서는
                 // 에러가 발생하지만 동작이 멈추면 안되고 다음 학기를 검색해야함

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/repository/ChapelRepository.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/repository/ChapelRepository.kt
@@ -1,5 +1,6 @@
 package com.yourssu.soomsil.usaint.data.repository
 
+import com.yourssu.soomsil.usaint.core.model.ChapelAttendanceData
 import com.yourssu.soomsil.usaint.core.model.ChapelData
 import com.yourssu.soomsil.usaint.core.model.SemesterData
 import com.yourssu.soomsil.usaint.core.types.SemesterType
@@ -39,20 +40,12 @@ class ChapelRepository @Inject constructor(
     // getCurrentSemesterUseCase를 사용하기가 어려워서
     // 전체 채플 데이터에서 DataStore에 저장한 분반 정보를 비교하여 뽑아냅니다.
     val chapelCard: Flow<ChapelData?> = // 현재 학기 설정에 따른 카드에 표시할 채플정보
-            chapels.map { chapelList ->
-                chapelList.find {
-                    val savedCardData = chapelDataSource.chapelCardData.first()
-
-                    it.chapelSimpleData.division == savedCardData.division
-                            // 채플 주차별 정보에서 첫 수업일자를 가져와서 설정한 현재연도와 일치하는지 확인
-                            // 해당학기 채플 주차별 데이터가 불러와지기 전 chapelCard를 호출하는 경우 ArrayIndexOutOfBoundsException
-                            && (it.chapelAttendances.any() && it.chapelAttendances[0].classDate.startsWith(savedCardData.year.toString()))
-                            // 수업 월이 7월 이전이면 1학기 채플인지 확인하고 8월 이후면 2학기 채플인것을 확인하고 현재 채플 정보로 반영
-                            // (같은 학년도에 같은 분반으로 1,2학기 수업을 들을 경우 여기서 걸러져야 함)
-                            && ((it.chapelAttendances[0].classDate.substring(5, 7).toInt() <= 7 && savedCardData.semester == SemesterType.One)
-                                || (it.chapelAttendances[0].classDate.substring(5, 7).toInt() > 7 && savedCardData.semester == SemesterType.Two))
-                }
+        chapels.map { chapelList ->
+            chapelList.find {
+                it.chapelSimpleData.year == chapelDataSource.chapelCardData.first().year &&
+                        it.chapelSimpleData.semester == chapelDataSource.chapelCardData.first().semester
             }
+        }
 
     // 앱이 최초에 실행될 때 이 함수가 먼저 실행됩니다.
     // 채플 DB와 DataStore에 불러온 값을 저장합니다.
@@ -64,16 +57,9 @@ class ChapelRepository @Inject constructor(
             specifiedCurrentSemester.second
         )
 
-        // TODO 기존 채플 과목코드에 대해 지우는 코드입니다. 나중에 삭제해주세요
-        chapelDao.deleteChapelAttendancesEntitiesWithDivision(chapelCardData.chapelSimpleData.division)
-        chapelDao.deleteChapelEntityWithDivision(chapelCardData.chapelSimpleData.division)
-        // ---
-
         chapelDataSource.setChapelCardData(chapelSimpleData = chapelCardData.chapelSimpleData)
         chapelDao.upsertChapel(chapelCardData.chapelSimpleData.asEntity())
-        chapelDao.upsertChapelAttendances(chapelCardData.chapelAttendances.map {
-            it.asEntity(specifiedCurrentSemester.first, specifiedCurrentSemester.second)
-        })
+        chapelDao.upsertChapelAttendances(chapelCardData.chapelAttendances.map(ChapelAttendanceData::asEntity))
     }
 
     // 현재 학기를 제외한 이수한 학기의 채플 정보를 모두 불러옵니다.
@@ -90,15 +76,9 @@ class ChapelRepository @Inject constructor(
                     semesterData.semester
                 )
 
-                // TODO 기존 채플 과목코드에 대해 지우는 코드입니다. 나중에 삭제해주세요
-                chapelDao.deleteChapelAttendancesEntitiesWithDivision(chapelData.chapelSimpleData.division)
-                chapelDao.deleteChapelEntityWithDivision(chapelData.chapelSimpleData.division)
-                // ---
-
                 chapelDao.upsertChapel(chapelData.chapelSimpleData.asEntity())
-                chapelDao.upsertChapelAttendances(chapelData.chapelAttendances.map {
-                    it.asEntity(semesterData.year, semesterData.semester)
-                })
+                chapelDao.upsertChapelAttendances(chapelData.chapelAttendances.map(
+                    ChapelAttendanceData::asEntity))
             } catch (e: Exception) {
                 // 계절학기, 6회 수강 완료 등 채플 데이터가 없는 학기에 대해서는
                 // 에러가 발생하지만 동작이 멈추면 안되고 다음 학기를 검색해야함

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/source/local/AppDatabase.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/source/local/AppDatabase.kt
@@ -14,12 +14,12 @@ import com.yourssu.soomsil.usaint.data.source.local.entity.SemesterEntity
 
 @Database(
     entities = [SemesterEntity::class, LectureEntity::class, ChapelEntity::class, ChapelAttendanceEntity::class],
-    version = 5,
+     version = 6,
     autoMigrations = [
         AutoMigration(from = 1, to = 2),
         AutoMigration(from = 2, to = 3),
         AutoMigration(from = 3, to = 4, spec = DatabaseMigrations.Schema3to4::class),
-        AutoMigration(from = 4, to = 5)
+        AutoMigration(from = 4, to = 5),
     ],
     exportSchema = true,
 )

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/source/local/DatabaseMigrations.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/source/local/DatabaseMigrations.kt
@@ -53,24 +53,24 @@ object DatabaseMigrations {
             """)
 
             // 1-2. Chapel: 기존 테이블에서 데이터 복사 및 변환
-            db.execSQL("""
-                INSERT INTO Chapel_temp (
-                    year, semester, division, chapelTime, chapelRoom,
-                    floorLevel, seatNumber, absenceTime, result
-                )
-                SELECT
-                    (division % 100000) / 10 AS year,
-                    CASE (division % 100000) % 10
-                        WHEN 0 THEN 'One'
-                        WHEN 1 THEN 'Two'
-                        WHEN 2 THEN 'Summer'
-                        WHEN 3 THEN 'Winter'
-                        ELSE 'One'
-                    END AS semester,
-                    division / 100000 AS division,
-                    chapelTime, chapelRoom, floorLevel, seatNumber, absenceTime, result
-                FROM Chapel
-            """)
+//            db.execSQL("""
+//                INSERT INTO Chapel_temp (
+//                    year, semester, division, chapelTime, chapelRoom,
+//                    floorLevel, seatNumber, absenceTime, result
+//                )
+//                SELECT
+//                    (division % 100000) / 10 AS year,
+//                    CASE (division % 100000) % 10
+//                        WHEN 0 THEN 'One'
+//                        WHEN 1 THEN 'Two'
+//                        WHEN 2 THEN 'Summer'
+//                        WHEN 3 THEN 'Winter'
+//                        ELSE 'One'
+//                    END AS semester,
+//                    division / 100000 AS division,
+//                    chapelTime, chapelRoom, floorLevel, seatNumber, absenceTime, result
+//                FROM Chapel
+//            """)
 
             // 1-3. Chapel: 기존 테이블 삭제
             db.execSQL("DROP TABLE Chapel")
@@ -108,25 +108,25 @@ object DatabaseMigrations {
 
 
             // 2. 기존 테이블에서 데이터 복사 (이전과 동일)
-            db.execSQL("""
-                INSERT INTO ChapelAttendance_temp (
-                    year, semester, division, classDate, category, instructor,
-                    instructorDepartment, title, attendance, result, note
-                )
-                SELECT
-                    (division % 100000) / 10 AS year,
-                    CASE (division % 100000) % 10
-                        WHEN 0 THEN 'One'
-                        WHEN 1 THEN 'Two'
-                        WHEN 2 THEN 'Summer'
-                        WHEN 3 THEN 'Winter'
-                        ELSE 'One'
-                    END AS semester,
-                    division / 100000 AS division,
-                    classDate, category, instructor, instructorDepartment,
-                    title, attendance, result, note
-                FROM ChapelAttendance
-            """)
+//            db.execSQL("""
+//                INSERT INTO ChapelAttendance_temp (
+//                    year, semester, division, classDate, category, instructor,
+//                    instructorDepartment, title, attendance, result, note
+//                )
+//                SELECT
+//                    (division % 100000) / 10 AS year,
+//                    CASE (division % 100000) % 10
+//                        WHEN 0 THEN 'One'
+//                        WHEN 1 THEN 'Two'
+//                        WHEN 2 THEN 'Summer'
+//                        WHEN 3 THEN 'Winter'
+//                        ELSE 'One'
+//                    END AS semester,
+//                    division / 100000 AS division,
+//                    classDate, category, instructor, instructorDepartment,
+//                    title, attendance, result, note
+//                FROM ChapelAttendance
+//            """)
 
             // 3. 기존 테이블 삭제
             db.execSQL("DROP TABLE ChapelAttendance")

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/source/local/DatabaseMigrations.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/source/local/DatabaseMigrations.kt
@@ -3,6 +3,8 @@ package com.yourssu.soomsil.usaint.data.source.local
 import androidx.room.DeleteColumn
 import androidx.room.DeleteTable
 import androidx.room.migration.AutoMigrationSpec
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 
 object DatabaseMigrations {
     @DeleteColumn(
@@ -23,4 +25,117 @@ object DatabaseMigrations {
     )
     @DeleteTable(tableName = "total_report_card")
     class Schema3to4 : AutoMigrationSpec
+
+    val MIGRATION_5_6 = object : Migration(5, 6) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL("PRAGMA foreign_keys=off")
+
+            // ==================== Chapel 테이블 마이그레이션 시작 ====================
+
+            // 1-1. Chapel: 새로운 스키마로 임시 테이블 생성
+            db.execSQL("""
+                CREATE TABLE Chapel_temp (
+                    year INTEGER NOT NULL DEFAULT 0,
+                    semester TEXT NOT NULL DEFAULT 'One',
+                    division INTEGER NOT NULL DEFAULT 0,
+                    chapelTime TEXT NOT NULL,
+                    chapelRoom TEXT NOT NULL,
+                    floorLevel INTEGER NOT NULL,
+                    seatNumber TEXT NOT NULL,
+                    absenceTime INTEGER NOT NULL,
+                    result TEXT NOT NULL,
+                    PRIMARY KEY(year, semester, division)
+                )
+            """)
+            db.execSQL("""
+                CREATE UNIQUE INDEX IF NOT EXISTS index_Chapel_division
+                ON Chapel_temp (division)
+            """)
+
+            // 1-2. Chapel: 기존 테이블에서 데이터 복사 및 변환
+            db.execSQL("""
+                INSERT INTO Chapel_temp (
+                    year, semester, division, chapelTime, chapelRoom,
+                    floorLevel, seatNumber, absenceTime, result
+                )
+                SELECT
+                    (division % 100000) / 10 AS year,
+                    CASE (division % 100000) % 10
+                        WHEN 0 THEN 'One'
+                        WHEN 1 THEN 'Two'
+                        WHEN 2 THEN 'Summer'
+                        WHEN 3 THEN 'Winter'
+                        ELSE 'One'
+                    END AS semester,
+                    division / 100000 AS division,
+                    chapelTime, chapelRoom, floorLevel, seatNumber, absenceTime, result
+                FROM Chapel
+            """)
+
+            // 1-3. Chapel: 기존 테이블 삭제
+            db.execSQL("DROP TABLE Chapel")
+
+            // 1-4. Chapel: 임시 테이블 이름을 원래 테이블 이름으로 변경
+            db.execSQL("ALTER TABLE Chapel_temp RENAME TO Chapel")
+
+            // ===================== Chapel 테이블 마이그레이션 종료 =====================
+
+
+            // 1. 새로운 스키마로 임시 테이블 생성 (FOREIGN KEY 구문 추가)
+            db.execSQL("""
+                CREATE TABLE ChapelAttendance_temp (
+                    year INTEGER NOT NULL DEFAULT 0,
+                    semester TEXT NOT NULL DEFAULT 'One',
+                    division INTEGER NOT NULL DEFAULT 0,
+                    classDate TEXT NOT NULL,
+                    category TEXT NOT NULL,
+                    instructor TEXT NOT NULL,
+                    instructorDepartment TEXT NOT NULL,
+                    title TEXT NOT NULL,
+                    attendance TEXT NOT NULL,
+                    result TEXT NOT NULL,
+                    note TEXT NOT NULL,
+                    PRIMARY KEY(year, semester, classDate),
+                    FOREIGN KEY(division) REFERENCES Chapel(division) ON UPDATE NO ACTION ON DELETE CASCADE
+                )
+            """)
+
+            // UNIQUE 인덱스 생성 구문 추가
+            db.execSQL("""
+                CREATE UNIQUE INDEX IF NOT EXISTS index_ChapelAttendance_year_semester_classDate
+                ON ChapelAttendance_temp (year, semester, classDate)
+            """)
+
+
+            // 2. 기존 테이블에서 데이터 복사 (이전과 동일)
+            db.execSQL("""
+                INSERT INTO ChapelAttendance_temp (
+                    year, semester, division, classDate, category, instructor,
+                    instructorDepartment, title, attendance, result, note
+                )
+                SELECT
+                    (division % 100000) / 10 AS year,
+                    CASE (division % 100000) % 10
+                        WHEN 0 THEN 'One'
+                        WHEN 1 THEN 'Two'
+                        WHEN 2 THEN 'Summer'
+                        WHEN 3 THEN 'Winter'
+                        ELSE 'One'
+                    END AS semester,
+                    division / 100000 AS division,
+                    classDate, category, instructor, instructorDepartment,
+                    title, attendance, result, note
+                FROM ChapelAttendance
+            """)
+
+            // 3. 기존 테이블 삭제
+            db.execSQL("DROP TABLE ChapelAttendance")
+
+            // 4. 임시 테이블 이름을 원래 테이블 이름으로 변경
+            db.execSQL("ALTER TABLE ChapelAttendance_temp RENAME TO ChapelAttendance")
+
+            db.execSQL("PRAGMA foreign_keys=on")
+        }
+    }
+
 }

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/source/local/dao/ChapelDao.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/source/local/dao/ChapelDao.kt
@@ -2,10 +2,8 @@ package com.yourssu.soomsil.usaint.data.source.local.dao
 
 import androidx.room.Dao
 import androidx.room.Query
-import androidx.room.Transaction
 import androidx.room.Upsert
 import com.yourssu.soomsil.usaint.data.source.local.entity.ChapelAttendanceEntity
-import com.yourssu.soomsil.usaint.data.source.local.entity.ChapelDataWithAttendance
 import com.yourssu.soomsil.usaint.data.source.local.entity.ChapelEntity
 import kotlinx.coroutines.flow.Flow
 

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/source/local/dao/ChapelDao.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/source/local/dao/ChapelDao.kt
@@ -36,8 +36,17 @@ interface ChapelDao {
     @Query("DELETE FROM Chapel WHERE year = :year AND semester = :semesterName")
     suspend fun deleteChapelEntitiesWithYearSemester(year: Int, semesterName: String)
 
+    /**
+     * @param division (division * 100000) + (year * 10) + semester.ordinal의 값으로 넣어주세요.
+     */
+    @Query("DELETE FROM Chapel WHERE division = :division")
+    suspend fun deleteChapelEntityWithDivision(division: Long)
+
+    /**
+     * @param division (division * 100000) + (year * 10) + semester.ordinal의 값으로 넣어주세요.
+     */
     @Query("DELETE FROM ChapelAttendance WHERE division = :division")
-    suspend fun deleteChapelAttendancesEntitiesWithDivision(division: Int)
+    suspend fun deleteChapelAttendancesEntitiesWithDivision(division: Long)
 
     @Query("DELETE FROM Chapel")
     suspend fun deleteAllChapel()

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/source/local/dao/ChapelDao.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/source/local/dao/ChapelDao.kt
@@ -11,18 +11,14 @@ import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface ChapelDao {
-    @Transaction
-    @Query("SELECT * FROM Chapel WHERE year = :year AND semester = :semesterName LIMIT 1")
-    fun getChapel(year: Int, semesterName: String): Flow<ChapelDataWithAttendance>
 
-    @Transaction
-    @Query("SELECT * FROM Chapel LIMIT 1")
-    fun getOneChapel(): Flow<List<ChapelDataWithAttendance>>
-
-
-    @Transaction
+    // 1. Chapel 테이블의 모든 데이터를 가져오는 쿼리
     @Query("SELECT * FROM Chapel")
-    fun getChapels(): Flow<List<ChapelDataWithAttendance>>
+    fun getAllChapels(): Flow<List<ChapelEntity>>
+
+    // 2. ChapelAttendance 테이블의 모든 데이터를 가져오는 쿼리
+    @Query("SELECT * FROM ChapelAttendance")
+    fun getAllAttendances(): Flow<List<ChapelAttendanceEntity>>
 
     @Upsert
     suspend fun upsertChapel(entity: ChapelEntity)

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/source/local/datastore/ChapelDataSource.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/source/local/datastore/ChapelDataSource.kt
@@ -17,7 +17,7 @@ class ChapelDataSource @Inject constructor (
         .map {
             ChapelSimpleData(
                 year = it.year,
-                semester = SemesterType.One,
+                semester = SemesterType.valueOf(it.semester),
                 division = it.division,
                 chapelRoom = it.chapelRoom,
                 chapelTime = it.chapelTime,

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/source/local/entity/ChapelAttendanceEntity.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/source/local/entity/ChapelAttendanceEntity.kt
@@ -5,6 +5,7 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import com.yourssu.soomsil.usaint.core.model.ChapelAttendanceData
+import com.yourssu.soomsil.usaint.core.types.SemesterType
 
 
 @Entity(
@@ -34,7 +35,7 @@ data class ChapelAttendanceEntity(
 )
 
 fun ChapelAttendanceEntity.asExternalModel() = ChapelAttendanceData(
-    division = division,
+    division = division / 100000,
     classDate = classDate,
     category = category,
     instructor = instructor,
@@ -45,8 +46,8 @@ fun ChapelAttendanceEntity.asExternalModel() = ChapelAttendanceData(
     note = note
 )
 
-fun ChapelAttendanceData.asEntity() = ChapelAttendanceEntity(
-    division = division,
+fun ChapelAttendanceData.asEntity(year: Int, semester: SemesterType) = ChapelAttendanceEntity(
+    division = (division * 100000) + (year * 10) + semester.ordinal,
     classDate = classDate,
     category = category,
     instructor = instructor,

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/source/local/entity/ChapelAttendanceEntity.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/source/local/entity/ChapelAttendanceEntity.kt
@@ -10,18 +10,22 @@ import com.yourssu.soomsil.usaint.core.types.SemesterType
 
 @Entity(
     tableName = "ChapelAttendance",
-    primaryKeys = ["division", "classDate"],
+    primaryKeys = ["year", "semester", "classDate"],
     foreignKeys = [ForeignKey(
         entity = ChapelEntity::class,
-        parentColumns = ["division"],
-        childColumns = ["division"],
+        parentColumns = ["year", "semester", "division"],
+        childColumns = ["year", "semester", "division"],
         onDelete = ForeignKey.CASCADE,
     )],
     indices = [
-        Index(value = ["division", "classDate"], unique = true)
+        Index(value = ["year", "semester", "classDate"], unique = true)
     ]
 )
 data class ChapelAttendanceEntity(
+    @ColumnInfo(defaultValue = "0")
+    val year: Int,
+    @ColumnInfo(defaultValue = "One")
+    val semester: String,
     @ColumnInfo(defaultValue = "0")
     val division: Long,
     val classDate: String,
@@ -35,7 +39,9 @@ data class ChapelAttendanceEntity(
 )
 
 fun ChapelAttendanceEntity.asExternalModel() = ChapelAttendanceData(
-    division = division / 100000,
+    year = year,
+    semester = SemesterType.valueOf(semester),
+    division = division,
     classDate = classDate,
     category = category,
     instructor = instructor,
@@ -46,8 +52,10 @@ fun ChapelAttendanceEntity.asExternalModel() = ChapelAttendanceData(
     note = note
 )
 
-fun ChapelAttendanceData.asEntity(year: Int, semester: SemesterType) = ChapelAttendanceEntity(
-    division = (division * 100000) + (year * 10) + semester.ordinal,
+fun ChapelAttendanceData.asEntity() = ChapelAttendanceEntity(
+    year = year,
+    semester = semester.name,
+    division = division,
     classDate = classDate,
     category = category,
     instructor = instructor,

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/source/local/entity/ChapelDataEntity.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/source/local/entity/ChapelDataEntity.kt
@@ -1,13 +1,6 @@
 package com.yourssu.soomsil.usaint.data.source.local.entity
 
-import androidx.room.Embedded
-import androidx.room.Relation
-
 data class ChapelDataWithAttendance(
-    @Embedded val chapel: ChapelEntity,
-    @Relation(
-        parentColumn = "division",
-        entityColumn = "division"
-    )
+    val chapel: ChapelEntity,
     val attendances: List<ChapelAttendanceEntity>
 )

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/source/local/entity/ChapelEntity.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/source/local/entity/ChapelEntity.kt
@@ -32,7 +32,7 @@ data class ChapelEntity(
 fun ChapelEntity.asExternalModel() = ChapelSimpleData(
     year = year,
     semester = enumValueOf<SemesterType>(semester),
-    division = division,
+    division = division / 100000,
     chapelTime = chapelTime,
     chapelRoom = chapelRoom,
     floorLevel = floorLevel,
@@ -45,7 +45,7 @@ fun ChapelEntity.asExternalModel() = ChapelSimpleData(
 fun ChapelSimpleData.asEntity() = ChapelEntity(
     year = year,
     semester = semester.name,
-    division = division,
+    division = (division * 100000) + (year * 10) + semester.ordinal,
     chapelTime = chapelTime,
     chapelRoom = chapelRoom,
     floorLevel = floorLevel,

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/source/local/entity/ChapelEntity.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/source/local/entity/ChapelEntity.kt
@@ -3,14 +3,14 @@ package com.yourssu.soomsil.usaint.data.source.local.entity
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Index
-import androidx.room.PrimaryKey
 import com.yourssu.soomsil.usaint.core.model.ChapelSimpleData
 import com.yourssu.soomsil.usaint.core.types.SemesterType
 
 @Entity(
     tableName = "Chapel",
+    primaryKeys = ["year", "semester", "division"],
     indices = [
-        Index(value = ["division"], unique = true)
+        Index(value = ["year", "semester", "division"], unique = true)
     ]
 )
 data class ChapelEntity(
@@ -19,7 +19,6 @@ data class ChapelEntity(
     @ColumnInfo(defaultValue = "One")
     val semester: String,
     @ColumnInfo(defaultValue = "0")
-    @PrimaryKey(autoGenerate = false)
     val division: Long,          // primary key
     val chapelTime: String,
     val chapelRoom: String,
@@ -32,7 +31,7 @@ data class ChapelEntity(
 fun ChapelEntity.asExternalModel() = ChapelSimpleData(
     year = year,
     semester = enumValueOf<SemesterType>(semester),
-    division = division / 100000,
+    division = division,
     chapelTime = chapelTime,
     chapelRoom = chapelRoom,
     floorLevel = floorLevel,
@@ -45,7 +44,7 @@ fun ChapelEntity.asExternalModel() = ChapelSimpleData(
 fun ChapelSimpleData.asEntity() = ChapelEntity(
     year = year,
     semester = semester.name,
-    division = (division * 100000) + (year * 10) + semester.ordinal,
+    division = division,
     chapelTime = chapelTime,
     chapelRoom = chapelRoom,
     floorLevel = floorLevel,

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/source/remote/rusaint/Mapper.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/source/remote/rusaint/Mapper.kt
@@ -82,11 +82,15 @@ internal fun ChapelInformation.asExternalModel(year: Int, semester: SemesterType
         absenceTime = generalInformation.absenceTime.toInt(),
         result = generalInformation.result,
     ),
-    chapelAttendances = attendances.map((ChapelAttendance::asExternalModel))
+    chapelAttendances = attendances.map {
+        it.asExternalModel(year, semester)
+    }
 
 )
 
-internal fun ChapelAttendance.asExternalModel() = ChapelAttendanceData(
+internal fun ChapelAttendance.asExternalModel(year: Int, semester: SemesterType) = ChapelAttendanceData(
+    year = year,
+    semester = semester,
     division = division.toLong(),
     classDate = classDate,
     category = category,

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/di/DataBaseModule.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/di/DataBaseModule.kt
@@ -3,6 +3,7 @@ package com.yourssu.soomsil.usaint.di
 import android.content.Context
 import androidx.room.Room
 import com.yourssu.soomsil.usaint.data.source.local.AppDatabase
+import com.yourssu.soomsil.usaint.data.source.local.DatabaseMigrations
 import com.yourssu.soomsil.usaint.data.source.local.dao.ChapelDao
 import com.yourssu.soomsil.usaint.data.source.local.dao.LectureDao
 import com.yourssu.soomsil.usaint.data.source.local.dao.SemesterDao
@@ -23,7 +24,9 @@ object DataBaseModule {
             context,
             AppDatabase::class.java,
             "my_database"
-        ).build()
+        )
+            .addMigrations(DatabaseMigrations.MIGRATION_5_6)
+            .build()
     }
 
     @Provides

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/components/ChapelCardItem.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/components/ChapelCardItem.kt
@@ -70,7 +70,7 @@ fun ChapelCardItem(
                                 SpanStyle(color = MaterialTheme.colorScheme.primary)
                             ) {
                                 append(
-                                    "${ceil(totalAttendance * (2 / 3.0)) - currentAttendance}회 "
+                                    "${ceil(totalAttendance * (2 / 3.0)).toInt() - currentAttendance}회 "
                                 )
                             }
                             append("남았어요.")

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/login/LoginViewModel.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/login/LoginViewModel.kt
@@ -55,6 +55,10 @@ class LoginViewModel @Inject constructor(
             // id/pw 저장
             studentCredentialRepository.setStudentCredential(credential)
             // 저장된 id/pw로 학생 데이터 가져오기 시도
+            getCurrentSemesterUseCase()?.let {
+                chapelRepository.fetchChapelCardData(it)
+                    .onFailure { e -> Timber.e(e) }
+            }
             studentDataRepository.fetchStudentData()
                 .onSuccess {
                     studentCredentialRepository.setLoggedIn(true)
@@ -64,11 +68,6 @@ class LoginViewModel @Inject constructor(
                 .onFailure { e ->
                     _uiEvent.emit(LoginUiEvent.Failure(e.message))
                 }
-
-            getCurrentSemesterUseCase()?.let {
-                chapelRepository.fetchChapelCardData(it)
-                    .onFailure { e -> Timber.e(e) }
-            }
 
             isLoading = false
         }


### PR DESCRIPTION
## 📝작업 내용

> 이전 PR에 올렸떤던 코드를 전부 날리고 DB구조를 수정해서 수업 데이터에도 학기정보가 들어가도록 수정했습니다~
- Chapel 테이블에서는 division만 기본키였는데, year, semeter, division 3개로 복합키 구성했어요
- ChapelAttendance 테이블에서도 divison만 외래키/기본키 였는데 year, semeter, divison으로 외래키/복합키로 구성했습니다!
<img width="1796" height="444" alt="Android Studio 2025 09 25 151552@2x" src="https://github.com/user-attachments/assets/4b8c51fe-ed6d-4125-8846-78bd2729ebef" />



<img width="400" height="914" alt="Android Studio 2025 09 25 155552@2x" src="https://github.com/user-attachments/assets/088ad412-32c1-4c20-a874-059310dc157b" />


<img width="400" height="914" alt="Android Studio 2025 09 25 155549@2x" src="https://github.com/user-attachments/assets/af71e3c5-9907-41ca-9c7c-b5b175f3186e" />


## 💬리뷰 요구사항(선택)

> 일단 에뮬레이터에서는 잘 되는거 확인했는데 DB 마이그레이션 잘 되는지 한번만 더 확인해볼게요
> 근데 지금 코드에 기존 데이터를 살리는 코드가 있긴 한데 저번 커밋에서 과목코드를 직접 만지기도 했고 아예 테이블을 새로 만들고 기존 데이터는 날리게 하는것도 괜찮을거같아요