### PR TITLE
현재학기 채플 데이터가 없는 경우에도 HomeScreen에서 채플카드 표시

### DIFF
--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/repository/ChapelRepository.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/repository/ChapelRepository.kt
@@ -2,6 +2,7 @@ package com.yourssu.soomsil.usaint.data.repository
 
 import com.yourssu.soomsil.usaint.core.model.ChapelAttendanceData
 import com.yourssu.soomsil.usaint.core.model.ChapelData
+import com.yourssu.soomsil.usaint.core.model.ChapelSimpleData
 import com.yourssu.soomsil.usaint.core.model.SemesterData
 import com.yourssu.soomsil.usaint.core.types.SemesterType
 import com.yourssu.soomsil.usaint.data.source.local.dao.ChapelDao
@@ -72,6 +73,19 @@ class ChapelRepository @Inject constructor(
                     ChapelAttendanceData::asEntity
                 )
             )
+        }.onFailure { // No chapel information provided
+            val tmpChapelCardData = ChapelSimpleData(
+                year = specifiedCurrentSemester.first,
+                semester = specifiedCurrentSemester.second,
+                division = 0, // <-- 0인거 중요!
+                chapelRoom = "",
+                chapelTime = "",
+                floorLevel = 0,
+                seatNumber = "",
+                absenceTime = 0,
+                result = ""
+            )
+            chapelDataSource.setChapelCardData(chapelSimpleData = tmpChapelCardData)
         }
 
     // 현재 학기를 제외한 이수한 학기의 채플 정보를 모두 불러옵니다.

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/domain/usecase/GetCurrentSemesterUseCase.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/domain/usecase/GetCurrentSemesterUseCase.kt
@@ -19,26 +19,26 @@ class GetCurrentSemesterUseCase @Inject constructor(
         val now = LocalDate.now()
         val year = now.year
 
-        // 2025년도 학기 개강 ~ 종강
+        // 2026년도 학기 개강 ~ 종강
         // https://ssu.ac.kr/%ED%95%99%EC%82%AC/%ED%95%99%EC%82%AC%EC%9D%BC%EC%A0%95/
-        // 1학기: 3/4 ~ 6/23 (성적 처리기간 ~7.7)
-        // 여름학기: 6/24 ~ 7/14 (성적 처리기간 ~7.31)
-        // 2학기: 9/1 ~ 12/20 (성적 처리기간 ~1.7)
-        // 겨울학기: 12/22 ~ 1/15 (성적 처리기간 ~1.31)
+        // 1학기: 3/1 ~ 6/22 (성적 처리기간 ~7.2)
+        // 여름학기: 6/23 ~ 7/13 (성적 처리기간 ~7.31)
+        // 2학기: 9/1 ~ 12/21 (성적 처리기간 ~1.3)
+        // 겨울학기: 12/22 ~ 1/14 (성적 처리기간 ~1.31)
         return when (now) {
-            in LocalDate.of(year, 3, 4)..LocalDate.of(year, 7, 7) ->
+            in LocalDate.of(year, 3, 1)..LocalDate.of(year, 7, 2) ->
                 Pair(year, SemesterType.One)
 
-            in LocalDate.of(year, 7, 8)..LocalDate.of(year, 7, 14) ->
+            in LocalDate.of(year, 7, 3)..LocalDate.of(year, 7, 13) ->
                 Pair(year, SemesterType.Summer)
 
             in LocalDate.of(year, 9, 1)..LocalDate.of(year, 12, 31) ->
                 Pair(year, SemesterType.Two)
 
-            in LocalDate.of(year, 1, 1)..LocalDate.of(year, 1, 7) ->
+            in LocalDate.of(year, 1, 1)..LocalDate.of(year, 1, 3) ->
                 Pair(year-1, SemesterType.Two)
 
-            in LocalDate.of(year, 1, 8)..LocalDate.of(year, 1, 31) ->
+            in LocalDate.of(year, 1, 4)..LocalDate.of(year, 1, 31) ->
                 Pair(year-1, SemesterType.Winter)
 
             else -> null

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/HomeScreen.kt
@@ -49,8 +49,8 @@ import com.yourssu.soomsil.usaint.core.model.ChapelData
 import com.yourssu.soomsil.usaint.core.model.ChapelSimpleData
 import com.yourssu.soomsil.usaint.core.model.ReportCardSummaryData
 import com.yourssu.soomsil.usaint.core.model.StudentData
-import com.yourssu.soomsil.usaint.screen.home.components.ActionTitleItem
 import com.yourssu.soomsil.usaint.screen.home.components.ChapelCardItem
+import com.yourssu.soomsil.usaint.screen.home.components.EmptyChapelCardItem
 import com.yourssu.soomsil.usaint.screen.home.components.ReportCardItem
 import com.yourssu.soomsil.usaint.screen.home.components.StudentDataItem
 import com.yourssu.soomsil.usaint.screen.reportcard.components.LectureItem
@@ -322,18 +322,18 @@ private fun HomeScreen(
                 color = MaterialTheme.colorScheme.onSurface,
             )
 
-            ActionTitleItem(
-                title = "\uD83C\uDF81 개강 선물 도착, 복권 뽑으러 가기!",
-                onClick = {
-                    if(studentData != null) {
-                        onPromotionClicked(studentData)
-                    } else {
-                        showFailedLoadToStudentDataSnackbar = true
-                    }
-                },
-            )
+//            ActionTitleItem(
+//                title = "\uD83C\uDF81 개강 선물 도착, 복권 뽑으러 가기!",
+//                onClick = {
+//                    if(studentData != null) {
+//                        onPromotionClicked(studentData)
+//                    } else {
+//                        showFailedLoadToStudentDataSnackbar = true
+//                    }
+//                },
+//            )
 
-            //나중에 성적시즌이 되면 주석 풀어주세요
+//            나중에 성적시즌이 되면 주석 풀어주세요
 //            if (studentData?.status == "재학") {
 //                Spacer(Modifier.height(8.dp))
 //                ActionTitleItem(
@@ -350,24 +350,27 @@ private fun HomeScreen(
                 reportCardSummary = reportCardSummaryData,
                 onReportCardClick = onReportCardClick,
             )
-
-            chapelCardData?.let {
-                Spacer(Modifier.height(8.dp))
-
-                val totalAttendance = it.chapelAttendances.size
-                val currentAttendance = it.chapelAttendances.filter { item ->
+            Spacer(Modifier.height(8.dp))
+            if(chapelCardData != null) {
+                val totalAttendance = chapelCardData.chapelAttendances.size
+                val currentAttendance = chapelCardData.chapelAttendances.filter { item ->
                     item.attendance == "출석"
                 }.size
 
-                // 앱 최초 실행 후 현재 학기에 채플 정보 없으면 카드 띄우지 않음
-                // 단, 채플 카드가 뜬 적이 있다면 채플 정보가 없는 학기로 수정해서 새로고침해도 기존 카드로 유지됨
-                if (it.chapelSimpleData.division != 0L)
+                // 과목코드(분반)이 0이면 해당 학기에는 채플 정보가 없는 상태입니다.
+                // fetch 과정에서 "No chapel information provided"에러가 발생했으면 0이 저장되어 있습니다
+                if (chapelCardData.chapelSimpleData.division != 0L) {
                     ChapelCardItem(
                         onChapelCardClick = onChapelCardClick,
                         chapelData = chapelCardData,
                         currentAttendance = currentAttendance,
                         totalAttendance = totalAttendance,
                     )
+                } else {
+                    EmptyChapelCardItem(onChapelCardClick = onChapelCardClick)
+                }
+            } else {
+                EmptyChapelCardItem(onChapelCardClick = onChapelCardClick)
             }
 
         }

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/components/ChapelCardItem.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/components/ChapelCardItem.kt
@@ -7,9 +7,11 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.KeyboardArrowRight
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
@@ -19,6 +21,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -29,6 +32,7 @@ import androidx.compose.ui.unit.dp
 import com.yourssu.soomsil.usaint.core.model.ChapelAttendanceData
 import com.yourssu.soomsil.usaint.core.model.ChapelData
 import com.yourssu.soomsil.usaint.core.model.ChapelSimpleData
+import com.yourssu.soomsil.usaint.core.model.SemesterData
 import com.yourssu.soomsil.usaint.ui.theme.SoomsilUSaintTheme
 import kotlin.math.ceil
 
@@ -227,6 +231,85 @@ fun ChapelCardItem(
     }
 }
 
+@Composable
+fun EmptyChapelCardItem(
+    onChapelCardClick: () -> Unit,
+    currentSemester: SemesterData? = null,
+    modifier: Modifier = Modifier,
+) {
+
+    var seatExpanded by remember { mutableStateOf(false) }
+
+    ElevatedCard(
+        modifier = modifier,
+        onClick = onChapelCardClick,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(
+                    vertical = 20.dp,
+                ),
+        ) {
+            Text(
+                text = "채플",
+                modifier = Modifier
+                    .padding(
+                        bottom = 4.dp,
+                        start = 16.dp,
+                        end = 16.dp,
+                    ),
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+
+            if(currentSemester != null) {
+                Text(
+                    modifier = Modifier
+                        .padding(
+                            bottom = 4.dp,
+                            start = 16.dp,
+                            end = 16.dp,
+                        ),
+                    text = "${currentSemester.year}년 ${currentSemester.semester}학기의 채플 데이터를 받아오지 못했어요."
+                )
+            } else {
+                Text(
+                    modifier = Modifier
+                        .padding(
+                            bottom = 4.dp,
+                            start = 16.dp,
+                            end = 16.dp,
+                        ),
+                    text = "이번 학기의 채플 데이터를 받아오지 못했어요."
+                )
+            }
+            HorizontalDivider(Modifier.padding(horizontal = 12.dp))
+            Row(
+                modifier = Modifier
+                    .padding(
+                        top = 4.dp,
+                        bottom = 4.dp,
+                        start = 16.dp,
+                        end = 16.dp,
+                        )
+                    .align(Alignment.CenterHorizontally)
+            ) {
+                Text(
+                    text = "과거 채플 수강기록 확인하러 가기"
+                )
+                Icon(
+                    imageVector = Icons.AutoMirrored.Outlined.KeyboardArrowRight,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurface,
+                )
+            }
+
+        }
+    }
+}
+
 @Preview
 @Composable
 fun ChapelCardItemPreview() {
@@ -239,6 +322,17 @@ fun ChapelCardItemPreview() {
             onChapelCardClick = {},
             totalAttendance = 10,
             currentAttendance = 5,
+        )
+    }
+}
+
+@Preview
+@Composable
+fun EmptyChapelCardItemPreview() {
+    SoomsilUSaintTheme {
+        EmptyChapelCardItem(
+            onChapelCardClick = {},
+            currentSemester = null
         )
     }
 }

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/setting/SettingScreen.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/setting/SettingScreen.kt
@@ -375,7 +375,7 @@ fun SettingScreen(
 
         if (showCurrentSemesterSettingDialog && settingUiState is SettingUiState.UserEditableSettings) {
             CurrentSemesterSettingDialog(
-                year = settingUiState.specifiedCurrentSemester?.first ?: 2025,
+                year = settingUiState.specifiedCurrentSemester?.first ?: 2026,
                 semester = settingUiState.specifiedCurrentSemester?.second ?: SemesterType.One,
                 onConfirmClick = { year, semester ->
                     onSpecifiedCurrentSemester(year, semester)


### PR DESCRIPTION
2026 성적 처리일정 반영
채플 정보를 최초로 불러올 때, semester가 공백으로 넘어오는 경우에 대한 예외처리 추가
<img width="352" height="498" alt="Android Studio 2026 03 05 000443@2x" src="https://github.com/user-attachments/assets/5384cbb8-c0c8-4ecd-8fcf-86708cabe630" />
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
