### PR TITLE
[0.2.10] Rusaint API 문제 임시조치

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.yourssu.soomsil.usaint"
         minSdk = 28
         targetSdk = 35
-        versionCode = 22
-        versionName = "0.2.9"
+        versionCode = 23
+        versionName = "0.2.10"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/HomeScreen.kt
@@ -29,9 +29,9 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -52,11 +52,13 @@ import com.yourssu.soomsil.usaint.core.model.StudentData
 import com.yourssu.soomsil.usaint.screen.home.components.ChapelCardItem
 import com.yourssu.soomsil.usaint.screen.home.components.EmptyChapelCardItem
 import com.yourssu.soomsil.usaint.screen.home.components.ReportCardItem
+import com.yourssu.soomsil.usaint.screen.home.components.ReportCardItemEmpty
 import com.yourssu.soomsil.usaint.screen.home.components.StudentDataItem
 import com.yourssu.soomsil.usaint.screen.reportcard.components.LectureItem
 import com.yourssu.soomsil.usaint.screen.setting.PasswordChangeDialog
 import com.yourssu.soomsil.usaint.ui.theme.SoomsilUSaintTheme
 import kotlinx.coroutines.launch
+
 @Composable
 fun HomeScreen(
     snackbarHostState: SnackbarHostState,
@@ -180,6 +182,14 @@ private fun HomeScreen(
             var showFailedLoadToStudentDataSnackbar by remember {
                 if (homeUiState is HomeUiState.Home)
                     homeUiState.showFailedLoadToStudentDataSnackbar
+                else
+                    mutableStateOf(false)
+            }
+
+            // TODO RUSAINT 고치면 삭제 바람
+            val isFailedFetch by remember {
+                if (homeUiState is HomeUiState.Home)
+                    homeUiState.isFailedFetch
                 else
                     mutableStateOf(false)
             }
@@ -333,7 +343,7 @@ private fun HomeScreen(
 //                },
 //            )
 
-//            나중에 성적시즌이 되면 주석 풀어주세요
+//            TODO 나중에 성적시즌이 되면 주석 풀어주세요
 //            if (studentData?.status == "재학") {
 //                Spacer(Modifier.height(8.dp))
 //                ActionTitleItem(
@@ -345,11 +355,17 @@ private fun HomeScreen(
 //                )
 //            }
 
-            Spacer(Modifier.height(8.dp))
-            ReportCardItem(
-                reportCardSummary = reportCardSummaryData,
-                onReportCardClick = onReportCardClick,
-            )
+            // TODO Rusaint 고치면 밑 조건문 삭제 바람
+            if(!isFailedFetch) {
+                Spacer(Modifier.height(8.dp))
+                ReportCardItem(
+                    reportCardSummary = reportCardSummaryData,
+                    onReportCardClick = onReportCardClick,
+                )
+            } else {
+                Spacer(Modifier.height(8.dp))
+                ReportCardItemEmpty()
+            }
             Spacer(Modifier.height(8.dp))
             if(chapelCardData != null) {
                 val totalAttendance = chapelCardData.chapelAttendances.size
@@ -397,7 +413,35 @@ private fun HomePreview_being() {
                 currentSemesterLectures = null,
                 currentSemesterData = null,
                 showPasswordIncorrectSnackbar = remember { mutableStateOf(false) },
-                showFailedLoadToStudentDataSnackbar = remember { mutableStateOf(false) }
+                showFailedLoadToStudentDataSnackbar = remember { mutableStateOf(false) },
+                isFailedFetch = remember { mutableStateOf(false) }
+            ),
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun HomePreview_RUSAINT_FAILED() {
+    // 재학 상태
+    SoomsilUSaintTheme {
+        HomeScreen(
+            hasInitialized = false,
+            isRefreshing = false,
+            onRefresh = {},
+            snackbarHostState = remember { SnackbarHostState() },
+            homeUiState = HomeUiState.Home(
+                studentData = StudentData.previewData,
+                reportCardSummaryData = ReportCardSummaryData.previewData,
+                chapelCardData = ChapelData(
+                    ChapelSimpleData.previewData,
+                    listOf(ChapelAttendanceData.previewData)
+                ),
+                currentSemesterLectures = null,
+                currentSemesterData = null,
+                showPasswordIncorrectSnackbar = remember { mutableStateOf(false) },
+                showFailedLoadToStudentDataSnackbar = remember { mutableStateOf(false) },
+                isFailedFetch = remember { mutableStateOf(true) }
             ),
         )
     }
@@ -423,7 +467,8 @@ private fun HomePreview_leave() {
                 currentSemesterLectures = null,
                 currentSemesterData = null,
                 showPasswordIncorrectSnackbar = remember { mutableStateOf(false) },
-                showFailedLoadToStudentDataSnackbar = remember { mutableStateOf(false) }
+                showFailedLoadToStudentDataSnackbar = remember { mutableStateOf(false) },
+                isFailedFetch = remember { mutableStateOf(false) }
             ),
         )
     }

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/HomeViewModel.kt
@@ -42,6 +42,7 @@ sealed interface HomeUiState {
         val currentSemesterData: SemesterData?,
         val showPasswordIncorrectSnackbar: MutableState<Boolean>,
         val showFailedLoadToStudentDataSnackbar: MutableState<Boolean>,
+        val isFailedFetch: MutableState<Boolean>,
     ) : HomeUiState
 }
 
@@ -57,6 +58,8 @@ class HomeViewModel @Inject constructor(
 ) : ViewModel() {
     private var showPasswordIncorrectSnackbar = mutableStateOf(false)
     private var showFailedLoadToStudentDataSnackbar = mutableStateOf(false)
+    //TODO Rusaint 수정될 시 삭제 바람
+    private var isFailedFetch = mutableStateOf(false)
     val homeUiState: StateFlow<HomeUiState> =
         combine(
             studentDataRepository.studentData,
@@ -76,6 +79,7 @@ class HomeViewModel @Inject constructor(
             },
             flowOf(showPasswordIncorrectSnackbar),
             flowOf(showFailedLoadToStudentDataSnackbar),
+            flowOf(isFailedFetch),
             transform = HomeUiState::Home,
         )
             .stateIn(
@@ -122,6 +126,12 @@ class HomeViewModel @Inject constructor(
                     //posthogTracker.trackLoginFailed(e)
                     showPasswordIncorrectSnackbar.value = true
 2                }
+                isFailedFetch.value = true
+                // TODO 비밀번호가 문제가 아니라면 채플 정보만 재시도. Rusaint API 수정될 시 삭제바람
+                getCurrentSemesterUseCase()?.let {
+                    chapelRepository.fetchChapelCardData(it)
+                        .onFailure { e -> Timber.e(e) }
+                }
             }
             isRefreshing = false
             hasInitialized = true
@@ -160,7 +170,7 @@ class HomeViewModel @Inject constructor(
     }
 
     // 나중에 다른 위치로 옮겨도 좋을거같습니다
-    private inline fun <T1, T2, T3, T4, T5, T6, T7, R> combine(
+    private inline fun <T1, T2, T3, T4, T5, T6, T7, T8, R> combine(
         flow: Flow<T1>,
         flow2: Flow<T2>,
         flow3: Flow<T3>,
@@ -168,9 +178,10 @@ class HomeViewModel @Inject constructor(
         flow5: Flow<T5>,
         flow6: Flow<T6>,
         flow7: Flow<T7>,
-        crossinline transform: suspend (T1, T2, T3, T4, T5, T6, T7) -> R
+        flow8: Flow<T8>,
+        crossinline transform: suspend (T1, T2, T3, T4, T5, T6, T7, T8) -> R
     ): Flow<R> {
-        return kotlinx.coroutines.flow.combine(flow, flow2, flow3, flow4, flow5, flow6, flow7) { args: Array<*> ->
+        return kotlinx.coroutines.flow.combine(flow, flow2, flow3, flow4, flow5, flow6, flow7, flow8) { args: Array<*> ->
             @Suppress("UNCHECKED_CAST")
             transform(
                 args[0] as T1,
@@ -180,6 +191,7 @@ class HomeViewModel @Inject constructor(
                 args[4] as T5,
                 args[5] as T6,
                 args[6] as T7,
+                args[7] as T8,
             )
         }
     }

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/components/ReportCardItem.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/components/ReportCardItem.kt
@@ -44,6 +44,33 @@ fun ReportCardItem(
     }
 }
 
+@Composable
+fun ReportCardItemEmpty(
+    modifier: Modifier = Modifier,
+) {
+    ElevatedCard(
+        modifier = modifier,
+    ) {
+        Column(
+            modifier = Modifier.padding(vertical = 16.dp),
+        ) {
+            Row(
+                modifier = modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = "아직 등록된 성적이 없어요",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+        }
+    }
+}
+
 // TODO 따로 분리하기
 @Composable
 fun ReportOutline(

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/login/LoginViewModel.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/login/LoginViewModel.kt
@@ -71,8 +71,25 @@ class LoginViewModel @Inject constructor(
                     posthogTracker.trackLogin(credential.id)
                 }
                 .onFailure { e ->
-                    posthogTracker.trackLoginFailed(e)
-                    _uiEvent.emit(LoginUiEvent.Failure(e.message))
+//                    posthogTracker.trackLoginFailed(e)
+//                    _uiEvent.emit(LoginUiEvent.Failure(e.message))
+
+                    // TODO RUSAINT API 수정 이후 밑 구문을 삭제해주세요. 성적 정보를 못불러오는 경우가 있습니다.
+                    // 성적 정보 가져오기에 실패한 경우 채플 정보만 불러옴
+                    getCurrentSemesterUseCase()?.let { // 현재 학기 채플 정보 불러오기
+                        chapelRepository.fetchChapelCardData(it)
+                            .onSuccess {
+                                studentCredentialRepository.setLoggedIn(true)
+                                _uiEvent.emit(LoginUiEvent.Success)
+                                posthogTracker.trackLogin(credential.id)
+                            }
+                            .onFailure { e ->
+                                // 로그인 실패 여부는 fetchStudentData()에서 한번에 판단
+                                posthogTracker.trackLoginFailed(e)
+                                _uiEvent.emit(LoginUiEvent.Failure(e.message))
+                                Timber.e(e)
+                            }
+                    }
                 }
 
             isLoading = false


### PR DESCRIPTION


## #️⃣연관된 이슈

- 해당 문제는 평균 학점값이 없는 1-1학기 재학중인 학생들에게 주로 나타는걸로 보임

## 📝작업 내용

> 성적 정보를 불러오지 못했더라도 채플 정보를 통해 다시 불러오기를 시도하고, 채플 정보를 불러왔다면 HomeScreen으로 이동시킴.
> 성적 정보 불러오기에 실패한 경우, HomeScreen에서 성적 탭으로 이동할 수 없도록 제한
