### PR TITLE
[0.2.12] 강의 정보, 성적 정보가 불러와지지 않는 문제 수정

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.yourssu.soomsil.usaint"
         minSdk = 28
         targetSdk = 35
-        versionCode = 23
-        versionName = "0.2.10"
+        versionCode = 25
+        versionName = "0.2.12"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/repository/ChapelRepository.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/repository/ChapelRepository.kt
@@ -49,9 +49,13 @@ class ChapelRepository @Inject constructor(
     // 전체 채플 데이터에서 DataStore에 저장한 분반 정보를 비교하여 뽑아냅니다.
     val chapelCard: Flow<ChapelData?> =
         combine(chapels, chapelDataSource.chapelCardData) { chapelList, cardData ->
-            chapelList.find {
-                it.chapelSimpleData.year == cardData.year &&
-                        it.chapelSimpleData.semester == cardData.semester
+            if (cardData == null) {
+                null
+            } else {
+                chapelList.find {
+                    it.chapelSimpleData.year == cardData.year &&
+                            it.chapelSimpleData.semester == cardData.semester
+                }
             }
         }
 

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/repository/ReportCardRepository.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/repository/ReportCardRepository.kt
@@ -12,6 +12,7 @@ import com.yourssu.soomsil.usaint.data.source.local.entity.asEntity
 import com.yourssu.soomsil.usaint.data.source.local.entity.asExternalModel
 import com.yourssu.soomsil.usaint.data.source.remote.USaintRemoteSource
 import com.yourssu.soomsil.usaint.domain.usecase.GetCurrentSemesterUseCase
+import com.yourssu.soomsil.usaint.domain.usecase.MakeSemesterUseCase
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import timber.log.Timber
@@ -24,6 +25,7 @@ class ReportCardRepository @Inject constructor(
     private val lectureDao: LectureDao,
     private val uSaintRemoteSource: USaintRemoteSource,
     private val getCurrentSemesterUseCase: GetCurrentSemesterUseCase,
+    private val makeSemesterUseCase: MakeSemesterUseCase,
 ) {
     val reportCardSummaryData: Flow<ReportCardSummaryData> =
         reportCardSummary.reportCardSummaryData
@@ -51,6 +53,8 @@ class ReportCardRepository @Inject constructor(
             currentSemester.second
         )
 
+        val semesterData = makeSemesterUseCase(currentSemester, lectureDataList)
+        semesterDao.upsertSemesters(listOf(semesterData.asEntity()))
         lectureDao.upsertLectures(lectureDataList.map(LectureData::asEntity))
 
     }

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/source/local/datastore/ChapelDataSource.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/source/local/datastore/ChapelDataSource.kt
@@ -13,11 +13,15 @@ import javax.inject.Inject
 class ChapelDataSource @Inject constructor (
     private val chapelDataSource: DataStore<ChapelDataProto>
 )  {
-    val chapelCardData: Flow<ChapelSimpleData> = chapelDataSource.data
+    val chapelCardData: Flow<ChapelSimpleData?> = chapelDataSource.data
         .map {
+            val semester = runCatching { SemesterType.valueOf(it.semester) }
+                .getOrNull()
+                ?: return@map null
+
             ChapelSimpleData(
                 year = it.year,
-                semester = SemesterType.valueOf(it.semester),
+                semester = semester,
                 division = it.division,
                 chapelRoom = it.chapelRoom,
                 chapelTime = it.chapelTime,

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/source/local/datastore/UserPreferencesDataSource.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/source/local/datastore/UserPreferencesDataSource.kt
@@ -84,7 +84,7 @@ class UserPreferencesDataSource @Inject constructor(
 
     suspend fun clear() {
         try {
-            userPreferences.updateData { UserPreferences.getDefaultInstance() }
+            userPreferences.updateData { UserPreferencesSerializer.defaultValue }
         } catch (e: IOException) {
             Timber.e("Failed to clear user preferences", e)
         }

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/source/local/datastore/UserPreferencesSerializer.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/data/source/local/datastore/UserPreferencesSerializer.kt
@@ -8,7 +8,9 @@ import java.io.InputStream
 import java.io.OutputStream
 
 object UserPreferencesSerializer : Serializer<UserPreferences> {
-    override val defaultValue: UserPreferences = UserPreferences.getDefaultInstance()
+    override val defaultValue: UserPreferences = UserPreferences.newBuilder()
+        .setAutoFetch(true)
+        .build()
 
     override suspend fun readFrom(input: InputStream): UserPreferences =
         try {

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/HomeScreen.kt
@@ -53,7 +53,6 @@ import com.yourssu.soomsil.usaint.screen.home.components.ActionTitleItem
 import com.yourssu.soomsil.usaint.screen.home.components.ChapelCardItem
 import com.yourssu.soomsil.usaint.screen.home.components.EmptyChapelCardItem
 import com.yourssu.soomsil.usaint.screen.home.components.ReportCardItem
-import com.yourssu.soomsil.usaint.screen.home.components.ReportCardItemEmpty
 import com.yourssu.soomsil.usaint.screen.home.components.StudentDataItem
 import com.yourssu.soomsil.usaint.screen.reportcard.components.LectureItem
 import com.yourssu.soomsil.usaint.screen.setting.PasswordChangeDialog
@@ -186,15 +185,6 @@ private fun HomeScreen(
                 else
                     mutableStateOf(false)
             }
-
-            // TODO RUSAINT 고치면 삭제 바람
-            val isFailedFetch by remember {
-                if (homeUiState is HomeUiState.Home)
-                    homeUiState.isFailedFetch
-                else
-                    mutableStateOf(false)
-            }
-
 
             if (showFailedLoadToStudentDataSnackbar) {
                 LaunchedEffect(Unit) {
@@ -356,17 +346,11 @@ private fun HomeScreen(
                 )
             }
 
-            // TODO Rusaint 고치면 밑 조건문 삭제 바람
-            if(!isFailedFetch) {
-                Spacer(Modifier.height(8.dp))
-                ReportCardItem(
+            Spacer(Modifier.height(8.dp))
+            ReportCardItem(
                     reportCardSummary = reportCardSummaryData,
                     onReportCardClick = onReportCardClick,
-                )
-            } else {
-                Spacer(Modifier.height(8.dp))
-                ReportCardItemEmpty()
-            }
+            )
             Spacer(Modifier.height(8.dp))
             if(chapelCardData != null) {
                 val totalAttendance = chapelCardData.chapelAttendances.size
@@ -415,7 +399,6 @@ private fun HomePreview_being() {
                 currentSemesterData = null,
                 showPasswordIncorrectSnackbar = remember { mutableStateOf(false) },
                 showFailedLoadToStudentDataSnackbar = remember { mutableStateOf(false) },
-                isFailedFetch = remember { mutableStateOf(false) }
             ),
         )
     }
@@ -442,7 +425,6 @@ private fun HomePreview_RUSAINT_FAILED() {
                 currentSemesterData = null,
                 showPasswordIncorrectSnackbar = remember { mutableStateOf(false) },
                 showFailedLoadToStudentDataSnackbar = remember { mutableStateOf(false) },
-                isFailedFetch = remember { mutableStateOf(true) }
             ),
         )
     }
@@ -469,7 +451,6 @@ private fun HomePreview_leave() {
                 currentSemesterData = null,
                 showPasswordIncorrectSnackbar = remember { mutableStateOf(false) },
                 showFailedLoadToStudentDataSnackbar = remember { mutableStateOf(false) },
-                isFailedFetch = remember { mutableStateOf(false) }
             ),
         )
     }

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/home/HomeViewModel.kt
@@ -42,7 +42,6 @@ sealed interface HomeUiState {
         val currentSemesterData: SemesterData?,
         val showPasswordIncorrectSnackbar: MutableState<Boolean>,
         val showFailedLoadToStudentDataSnackbar: MutableState<Boolean>,
-        val isFailedFetch: MutableState<Boolean>,
     ) : HomeUiState
 }
 
@@ -58,8 +57,6 @@ class HomeViewModel @Inject constructor(
 ) : ViewModel() {
     private var showPasswordIncorrectSnackbar = mutableStateOf(false)
     private var showFailedLoadToStudentDataSnackbar = mutableStateOf(false)
-    //TODO Rusaint 수정될 시 삭제 바람
-    private var isFailedFetch = mutableStateOf(false)
     val homeUiState: StateFlow<HomeUiState> =
         combine(
             studentDataRepository.studentData,
@@ -79,7 +76,6 @@ class HomeViewModel @Inject constructor(
             },
             flowOf(showPasswordIncorrectSnackbar),
             flowOf(showFailedLoadToStudentDataSnackbar),
-            flowOf(isFailedFetch),
             transform = HomeUiState::Home,
         )
             .stateIn(
@@ -125,12 +121,6 @@ class HomeViewModel @Inject constructor(
                     // TODO 이 지점에서 비밀번호 틀려서 로그인에 실패한걸 트래커에 보낼 필요가 있을까?
                     //posthogTracker.trackLoginFailed(e)
                     showPasswordIncorrectSnackbar.value = true
-2                }
-                isFailedFetch.value = true
-                // TODO 비밀번호가 문제가 아니라면 채플 정보만 재시도. Rusaint API 수정될 시 삭제바람
-                getCurrentSemesterUseCase()?.let {
-                    chapelRepository.fetchChapelCardData(it)
-                        .onFailure { e -> Timber.e(e) }
                 }
             }
             isRefreshing = false
@@ -170,7 +160,7 @@ class HomeViewModel @Inject constructor(
     }
 
     // 나중에 다른 위치로 옮겨도 좋을거같습니다
-    private inline fun <T1, T2, T3, T4, T5, T6, T7, T8, R> combine(
+    private inline fun <T1, T2, T3, T4, T5, T6, T7, R> combine(
         flow: Flow<T1>,
         flow2: Flow<T2>,
         flow3: Flow<T3>,
@@ -178,10 +168,9 @@ class HomeViewModel @Inject constructor(
         flow5: Flow<T5>,
         flow6: Flow<T6>,
         flow7: Flow<T7>,
-        flow8: Flow<T8>,
-        crossinline transform: suspend (T1, T2, T3, T4, T5, T6, T7, T8) -> R
+        crossinline transform: suspend (T1, T2, T3, T4, T5, T6, T7) -> R
     ): Flow<R> {
-        return kotlinx.coroutines.flow.combine(flow, flow2, flow3, flow4, flow5, flow6, flow7, flow8) { args: Array<*> ->
+        return kotlinx.coroutines.flow.combine(flow, flow2, flow3, flow4, flow5, flow6, flow7) { args: Array<*> ->
             @Suppress("UNCHECKED_CAST")
             transform(
                 args[0] as T1,
@@ -191,7 +180,6 @@ class HomeViewModel @Inject constructor(
                 args[4] as T5,
                 args[5] as T6,
                 args[6] as T7,
-                args[7] as T8,
             )
         }
     }

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/login/LoginViewModel.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/screen/login/LoginViewModel.kt
@@ -73,23 +73,6 @@ class LoginViewModel @Inject constructor(
                 .onFailure { e ->
 //                    posthogTracker.trackLoginFailed(e)
 //                    _uiEvent.emit(LoginUiEvent.Failure(e.message))
-
-                    // TODO RUSAINT API 수정 이후 밑 구문을 삭제해주세요. 성적 정보를 못불러오는 경우가 있습니다.
-                    // 성적 정보 가져오기에 실패한 경우 채플 정보만 불러옴
-                    getCurrentSemesterUseCase()?.let { // 현재 학기 채플 정보 불러오기
-                        chapelRepository.fetchChapelCardData(it)
-                            .onSuccess {
-                                studentCredentialRepository.setLoggedIn(true)
-                                _uiEvent.emit(LoginUiEvent.Success)
-                                posthogTracker.trackLogin(credential.id)
-                            }
-                            .onFailure { e ->
-                                // 로그인 실패 여부는 fetchStudentData()에서 한번에 판단
-                                posthogTracker.trackLoginFailed(e)
-                                _uiEvent.emit(LoginUiEvent.Failure(e.message))
-                                Timber.e(e)
-                            }
-                    }
                 }
 
             isLoading = false

--- a/app/src/main/kotlin/com/yourssu/soomsil/usaint/ui/USaintApp.kt
+++ b/app/src/main/kotlin/com/yourssu/soomsil/usaint/ui/USaintApp.kt
@@ -61,7 +61,7 @@ fun USaintApp(
         floatingActionButton = {
             FloatingActionButton(
                 contentColor = Color.White,
-                containerColor = Color(0x9A3333AA),
+                containerColor = Color.Blue,
                 onClick = {
                     val intent = Intent(
                         Intent.ACTION_VIEW,


### PR DESCRIPTION

## 📝작업 내용

- 로그아웃 시 앱이 터질 수 있는 문제
- 최초 로그인 시, 채플 정보만 불러와지고 성적 정보가 불러오지 않던 문제
- - autoFetch는 기본 true값 부여
- 불러오기 순서가 잘못되어 Room에 추가하지 못하던 문제
- Rusaint 임시 예외처리 삭제

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
